### PR TITLE
Improve timeline controls, fix tooltip bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -2102,24 +2102,25 @@ function zoomTimeline(factor, anchorFraction) {
   renderTimeline();
 }
 
-// Wheel event disambiguation: trackpads send horizontal deltaX for swipe (pan),
-// vertical deltaY with ctrlKey for pinch-to-zoom, and plain vertical scroll
-// which we intentionally ignore so the page scrolls normally.
+// Wheel event disambiguation: trackpads send horizontal deltaX for swipe (pan)
+// and vertical deltaY with ctrlKey for pinch-to-zoom.
 document.getElementById('timelineTrack').addEventListener('wheel', function(e) {
   e.preventDefault();
   const rect = this.getBoundingClientRect();
   const anchorFrac = (e.clientX - rect.left) / rect.width;
-  if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
+  if (e.shiftKey || Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
+    // Pan horizontally with with deltaX or shiftKey + deltaY
     const span = viewEnd - viewStart;
-    const shift = (e.deltaX / rect.width) * span;
+    const deltaX = e.shiftKey ? e.deltaY * 0.5 : e.deltaX;
+    const shift = (deltaX / rect.width) * span;
     viewStart += shift;
     viewEnd += shift;
     if (viewStart < T_START) { viewEnd += T_START - viewStart; viewStart = T_START; }
     if (viewEnd > T_END) { viewStart -= viewEnd - T_END; viewEnd = T_END; }
     if (viewStart < T_START) viewStart = T_START;
     renderTimeline();
-  } else if (e.ctrlKey) {
-    // Pinch-to-zoom on trackpad sets ctrlKey
+  } else {
+    // Zoom in/out with deltaY
     const factor = e.deltaY > 0 ? 1.15 : 0.87;
     zoomTimeline(factor, anchorFrac);
   }

--- a/index.html
+++ b/index.html
@@ -2016,7 +2016,7 @@ const tipActivity = document.getElementById('tipActivity');
 
 const timelineTrack = document.getElementById('timelineTrack');
 
-timelineTrack.addEventListener('mousemove', function(e) {
+function updateTooltip(e) {
   if (isDragging) { hoverTip.style.display = 'none'; return; }
   const rect = this.getBoundingClientRect();
   const frac = (e.clientX - rect.left) / rect.width;
@@ -2035,7 +2035,9 @@ timelineTrack.addEventListener('mousemove', function(e) {
   const leftPx = e.clientX - rect.left;
   const maxLeft = rect.width - 120;
   hoverTip.style.left = Math.max(60, Math.min(maxLeft, leftPx)) + 'px';
-});
+}
+
+timelineTrack.addEventListener('mousemove', updateTooltip);
 
 timelineTrack.addEventListener('mouseleave', function() {
   hoverTip.style.display = 'none';
@@ -2119,6 +2121,7 @@ document.getElementById('timelineTrack').addEventListener('wheel', function(e) {
     if (viewEnd > T_END) { viewStart -= viewEnd - T_END; viewEnd = T_END; }
     if (viewStart < T_START) viewStart = T_START;
     renderTimeline();
+    updateTooltip.call(this, e);
   } else {
     // Zoom in/out with deltaY
     const factor = e.deltaY > 0 ? 1.15 : 0.87;


### PR DESCRIPTION
New features/fixes:
- Add zoom control via scroll wheel (in addition to existing ctrl+scroll for trackpad compatibility)
- Add pan control via shift+scroll (similar to horizonal scroll bars in browser)
- Tooltips are updated while panning to avoid stale tooltip data

To test:
- Try scroll and shift+scroll when hovering over timeline
- Ensure tooltips are updated to current mouse position when panning via shift+scroll or trackpad

Notes:
- The horizontal zoom scaling constant (`0.5` on new line 2116) can be adjusted to taste; I tried to ensure a reasonable pan speed for default scroll settings on my computer