### PR TITLE
Fix mobile layout issues and hide duplicate photos

### DIFF
--- a/index.html
+++ b/index.html
@@ -1969,6 +1969,7 @@ let filteredPhotos = PHOTOS;
 let audioMuted = true;
 let currentAudio = null;
 let lastAudioClip = null;
+let descTipOpen = false;
 
 // Full timeline range
 const T_START = PHOTOS[0].t;
@@ -2360,13 +2361,13 @@ function updatePhoto() {
     titleRow.style.display = '';
     const fullDesc = flickrId ? (PHOTO_DESCS[flickrId] || nasaTitle) : nasaTitle;
     descTip.textContent = fullDesc || '';
-    descTip.classList.remove('open');
-    document.getElementById('descToggleBtn').setAttribute('aria-expanded', 'false');
+    descTip.classList.toggle('open', descTipOpen);
+    document.getElementById('descToggleBtn').setAttribute('aria-expanded', descTipOpen ? 'true' : 'false');
     setPhotoDescription(fullDesc);
   } else {
     titleRow.style.display = 'none';
     descTip.classList.remove('open');
-    document.getElementById('descToggleBtn').setAttribute('aria-expanded', 'false');
+    document.getElementById('descToggleBtn').setAttribute('aria-expanded', descTipOpen ? 'true' : 'false');
     setPhotoDescription(null);
   }
   document.getElementById('metaPhotographer').textContent = photo.p;
@@ -2841,8 +2842,9 @@ window.toggleDescTip = function() {
   const tip = document.getElementById('descHoverTip');
   const btn = document.getElementById('descToggleBtn');
   if (!tip || !btn) return;
-  const open = tip.classList.toggle('open');
-  btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+  descTipOpen = !descTipOpen;
+  tip.classList.toggle('open', descTipOpen);
+  btn.setAttribute('aria-expanded', descTipOpen ? 'true' : 'false');
 };
 
 // --- PHOTO DESCRIPTION BUTTON + POPUP ---
@@ -2855,9 +2857,13 @@ function setPhotoDescription(text) {
     if (text) { btn.style.display = ''; btn.dataset.text = text; }
     else      { btn.style.display = 'none'; btn.dataset.text = ''; }
   }
-  // Desktop UI — restored. CSS hides this on mobile so it doesn't double up
-  // with the new top-left "Show Desc" pill.
   if (descHover) descHover.style.display = text ? '' : 'none';
+  const modal = document.getElementById('descPopupModal');
+  const popupText = document.getElementById('descPopupText');
+  if (modal && modal.style.display === 'flex' && popupText) {
+    if (text) popupText.textContent = text;
+    else closeDescPopup();
+  }
 }
 
 window.showDescPopup = function() {

--- a/index.html
+++ b/index.html
@@ -649,7 +649,8 @@
     .photo-desc-btn { display: none !important; }
   }
   @media (max-width: 768px) {
-    .photo-desc-btn { display: none !important; }
+    .photo-links,
+    .desc-hover { display: none !important; }
   }
   /* Photo description button — top-left corner of the image, opens popup */
   .photo-desc-btn {
@@ -759,23 +760,9 @@
     vertical-align: middle;
   }
 
-  @media (max-width: 768px) {
-    /* Mobile bottom-sheet vars — single source of truth for snap points */
-    :root {
-      --sheet-handle-h: 44px;
-      --sheet-middle-h: 192px; /* orion map flush at top + a little chrome */
-      /* y-coord of the sheet's top edge; default matches the middle snap so
-         pre-JS layout already reserves the right space for the photo. */
-      --sheet-top-y: calc(var(--vh) - 192px);
-    }
+    @media (max-width: 768px) {
 
-    body { height: var(--vh); overflow: hidden; }
-    /* Mirror sheet-state on body so .viewer can size the photo so it
-       never sits underneath the sheet's top edge. The closed-state offset
-       includes the home-indicator gutter so the handle isn't clipped. */
-    body.sheet-state-open    { --sheet-top-y: 35vh; }
-    body.sheet-state-middle  { --sheet-top-y: calc(var(--vh) - var(--sheet-middle-h)); }
-    body.sheet-state-closed  { --sheet-top-y: calc(var(--vh) - var(--sheet-handle-h) - var(--safe-bottom)); }
+    body { height: auto; min-height: 100vh; overflow-y: auto; -webkit-overflow-scrolling: touch; }
     #header { flex-wrap: wrap; gap: 6px 12px; padding: 8px 12px; }
     #header h1 { font-size: 18px; }
     #header .crew { display: none; }
@@ -802,29 +789,13 @@
        the dropdown only half-width — drop it so the trigger fills the row. */
     .controls-row .controls-spacer { display: none; }
 
-    /* n/n photo counter — floats as a translucent pill above the sheet,
-       styled like the "Show Desc" button. position:fixed is used so the
-       element stays a flex child of controls-row in DOM (desktop layout
-       unchanged) but visually leaves the row on mobile. */
+    /* n/n photo counter — stays inline in the controls row on mobile, same
+       as desktop. */
     #photoCounter {
-      position: fixed;
-      bottom: calc(var(--vh) - var(--sheet-top-y) + 10px);
-      left: 50%;
-      transform: translateX(-50%);
-      z-index: 4;
-      background: rgba(0,0,0,0.55);
-      -webkit-backdrop-filter: blur(6px);
-      backdrop-filter: blur(6px);
-      border: 1px solid rgba(255,255,255,0.18);
-      color: #fff;
-      padding: 6px 14px;
-      border-radius: 999px;
-      font-size: 11px;
-      font-weight: 700;
-      letter-spacing: 0.8px;
-      text-transform: uppercase;
-      pointer-events: none;
-      transition: bottom 0.32s cubic-bezier(0.32, 0.72, 0, 1);
+      color: #4FC3F7;
+      font-size: 12px;
+      font-weight: 600;
+      white-space: nowrap;
     }
     .filter-dropdown-trigger {
       display: flex;
@@ -985,23 +956,19 @@
        the bottom border of the filters row. The viewer reserves space for
        the sheet up to the middle snap. Beyond that the sheet overlaps. */
     .viewer {
+      flex: none;
       flex-direction: column;
       padding: 0;
       gap: 0;
-      overflow: hidden;
-      padding-bottom: calc(min(var(--vh) - var(--sheet-top-y), var(--sheet-middle-h)) + 4px);
-    }
-    /* Middle snap: let the photo extend slightly past the sheet's top edge
-       so a sliver of image peeks through the rounded sheet corners. */
-    body.sheet-state-middle .viewer {
-      padding-bottom: calc(var(--sheet-middle-h) - 24px);
     }
     .photo-side {
-      flex: 1;
+      flex: none;
       min-height: 0;
-      max-height: none;
+      overflow: visible;
     }
     .photo-container {
+      flex: none;
+      min-height: 40vh;
       border: 0;
       border-radius: 0;
     }
@@ -1018,59 +985,16 @@
 
     /* ---------- BOTTOM SHEET ---------- */
     .meta-panel {
-      position: fixed;
-      left: 0;
-      right: 0;
-      bottom: 0;
       width: 100%;
       max-width: 100%;
-      max-height: none;
       flex-direction: column;
       flex-wrap: nowrap;
       gap: 0;
-      /* Bottom padding includes home-indicator gutter so the last scroll
-         row (data-sources) isn't clipped behind the indicator. */
       padding: 0 0 calc(24px + var(--safe-bottom));
       background: #0a0a14;
-      border-top: 1px solid #1a1a2e;
-      border-radius: 14px 14px 0 0;
-      box-shadow: 0 -8px 24px rgba(0,0,0,0.5);
-      z-index: 100;
-      overflow-y: auto;
-      -webkit-overflow-scrolling: touch;
-      overscroll-behavior: contain;
-      transition: top 0.32s cubic-bezier(0.32, 0.72, 0, 1);
-      /* default = middle */
-      top: calc(var(--vh) - var(--sheet-middle-h));
     }
-    .meta-panel.sheet-open    { top: 35vh; }
-    .meta-panel.sheet-middle  { top: calc(var(--vh) - var(--sheet-middle-h)); }
-    .meta-panel.sheet-closed  { top: calc(var(--vh) - var(--sheet-handle-h) - var(--safe-bottom)); overflow-y: hidden; }
-    .meta-panel.sheet-dragging { transition: none; }
-
-    /* Handle floats absolutely over the orion map; only the drag bar is
-       visible in open/middle states. Closed state lets the handle stretch
-       to fill the visible sheet area and reveal the title. */
-    .bottom-sheet-handle {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      z-index: 5;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: flex-start;
-      gap: 6px;
-      padding: 8px 16px 14px; /* generous bottom padding = comfortable touch target */
-      cursor: grab;
-      user-select: none;
-      -webkit-user-select: none;
-      -webkit-tap-highlight-color: transparent;
-      touch-action: none;
-      background: transparent;
-    }
-    .meta-panel.sheet-dragging .bottom-sheet-handle { cursor: grabbing; }
+    /* The bottom-sheet handle is hidden; no drag interaction on mobile */
+    .bottom-sheet-handle { display: none; }
     .sheet-handle-bar {
       width: 44px;
       height: 4px;
@@ -1085,47 +1009,32 @@
       letter-spacing: 0.3px;
     }
 
-    /* In closed state, stretch the handle to fill the (small) sheet so the
-       title sits over a solid background. Bottom padding accounts for the
-       iPhone home-indicator gutter so the title isn't sitting under it. */
-    .meta-panel.sheet-closed .bottom-sheet-handle {
-      bottom: 0;
-      justify-content: center;
-      background: #0a0a14;
-      padding: 8px 16px calc(8px + var(--safe-bottom));
-    }
 
-    /* Reorder: orion map first so it's the only thing visible at the middle snap.
-       Orion map is flush with sheet edges (no margin/border); the handle floats
-       on top of it. */
+
     .traj-section {
-      order: 1;
       margin: 0;
       padding: 0;
       border: none;
       border-radius: 14px 14px 0 0;
       background: rgba(0,0,0,0.35);
-      flex-shrink: 0;
       max-height: 140px;
       overflow: hidden;
     }
     .traj-section canvas {
       border-radius: 14px 14px 0 0;
       width: 100%;
-      height: 122px; /* leaves room for the trajectory label, total ≤140px */
+      height: 122px;
       object-fit: contain;
       display: block;
     }
     .traj-label { padding-bottom: 4px; }
-    .meta-panel > .calendar-promo { order: 2; margin: 10px 12px 0; flex-shrink: 0; }
-    .desc-hover { order: 3; margin: 10px 12px 0; width: auto; flex-shrink: 0; }
-    .meta-panel > .meta-section:not(#descSection) { order: 4; margin: 10px 12px 0; flex-shrink: 0; }
-    .meta-panel > #descSection { order: 5; margin: 10px 12px 0; flex-shrink: 0; }
-    .meta-panel > .data-sources { order: 6; margin-top: 14px; flex-shrink: 0; }
+    .meta-panel > .calendar-promo { margin: 10px 12px 0; }
+    .desc-hover { margin: 10px 12px 0; width: auto; }
+    .meta-panel > .meta-section:not(#descSection) { margin: 10px 12px 0; }
+    .meta-panel > #descSection { margin: 10px 12px 0; }
+    .meta-panel > .data-sources { margin: 0; padding: 16px 12px; }
 
-    /* Title only visible when sheet is closed */
     .sheet-handle-title { display: none; }
-    .meta-panel.sheet-closed .sheet-handle-title { display: block; }
 
     .meta-section { padding: 12px; }
     .meta-field { margin-bottom: 8px; }
@@ -1159,67 +1068,6 @@
     .calendar-subtitle { display: none; }
     .calendar-countdown-mobile { display: block; font-size: 11px; color: #4FC3F7; font-weight: 600; margin-top: 2px; }
     .calendar-link { margin-top: 6px; padding: 6px 14px; display: inline-block; font-size: 10px; }
-
-    body {
-      height: auto;
-      min-height: var(--vh);
-      overflow-y: auto;
-    }
-    .viewer {
-      flex: 0 0 auto;
-      overflow: visible;
-      padding-bottom: 0;
-    }
-    body.sheet-state-middle .viewer {
-      padding-bottom: 0;
-    }
-    .photo-side {
-      flex: none;
-      height: calc(var(--vh) - 148px);
-      min-height: 300px;
-      max-height: none;
-    }
-    .meta-panel {
-      position: static;
-      max-height: none;
-      border-radius: 0;
-      box-shadow: none;
-      overflow: visible;
-      transition: none;
-    }
-    .meta-panel.sheet-open,
-    .meta-panel.sheet-middle,
-    .meta-panel.sheet-closed {
-      top: auto;
-    }
-    .bottom-sheet-handle {
-      display: none;
-    }
-    #photoCounter {
-      position: static;
-      transform: none;
-      z-index: auto;
-      background: transparent;
-      border: 0;
-      padding: 0;
-      border-radius: 0;
-      color: #888;
-      transition: none;
-    }
-    .filter-popup-modal {
-      inset: auto 8px 8px;
-      max-height: min(620px, calc(var(--vh) - 24px));
-      border: 1px solid #2a2a4e;
-      border-radius: 8px;
-      box-shadow: 0 -8px 24px rgba(0,0,0,0.5);
-    }
-    .filter-popup-close {
-      border-radius: 8px 8px 0 0;
-    }
-    .filter-popup-body {
-      overflow-y: auto;
-      padding-bottom: calc(18px + var(--safe-bottom));
-    }
   }
 
   @media (max-width: 480px) {
@@ -2527,7 +2375,7 @@ const tipActivity = document.getElementById('tipActivity');
 const timelineTrack = document.getElementById('timelineTrack');
 
 function updateTooltip(e) {
-  if (isDragging) { hoverTip.style.display = 'none'; return; }
+  if (isDragging || isTimelineInteractiveTarget(e.target)) { hoverTip.style.display = 'none'; return; }
   const rect = this.getBoundingClientRect();
   const frac = (e.clientX - rect.left) / rect.width;
   const t = viewStart + (viewEnd - viewStart) * frac;
@@ -3065,36 +2913,7 @@ setInterval(updateCountdown, 3600000); // refresh hourly
 document.getElementById('calendarCover').src = MEDIA_BASE + 'web/Farther.png';
 
 
-const MOBILE_MQ = window.matchMedia('(max-width: 768px)');
-const sheetEl = document.getElementById('metaPanel');
-const descHoverEl = document.getElementById('descHover');
-const trajSectionEl = document.querySelector('.traj-section');
-const photoLinksEl = document.querySelector('.photo-side .photo-links');
 
-function relocateDescHoverForViewport() {
-  if (!descHoverEl) return;
-  if (MOBILE_MQ.matches) {
-    if (descHoverEl.parentElement !== sheetEl) {
-      trajSectionEl.insertAdjacentElement('afterend', descHoverEl);
-    }
-  } else {
-    if (photoLinksEl && descHoverEl.parentElement !== photoLinksEl) {
-      photoLinksEl.appendChild(descHoverEl);
-    }
-  }
-}
-
-function syncMobileLayout() {
-  relocateDescHoverForViewport();
-  if (!MOBILE_MQ.matches) {
-    sheetEl.classList.remove('sheet-open', 'sheet-middle', 'sheet-closed', 'sheet-dragging');
-    document.body.classList.remove('sheet-state-open', 'sheet-state-middle', 'sheet-state-closed');
-    sheetEl.style.top = '';
-  }
-}
-
-syncMobileLayout();
-window.addEventListener('resize', syncMobileLayout);
 
 
 })(); // end init

--- a/index.html
+++ b/index.html
@@ -649,7 +649,7 @@
     .photo-desc-btn { display: none !important; }
   }
   @media (max-width: 768px) {
-    .desc-hover { display: none !important; }
+    .photo-desc-btn { display: none !important; }
   }
   /* Photo description button — top-left corner of the image, opens popup */
   .photo-desc-btn {
@@ -1159,6 +1159,67 @@
     .calendar-subtitle { display: none; }
     .calendar-countdown-mobile { display: block; font-size: 11px; color: #4FC3F7; font-weight: 600; margin-top: 2px; }
     .calendar-link { margin-top: 6px; padding: 6px 14px; display: inline-block; font-size: 10px; }
+
+    body {
+      height: auto;
+      min-height: var(--vh);
+      overflow-y: auto;
+    }
+    .viewer {
+      flex: 0 0 auto;
+      overflow: visible;
+      padding-bottom: 0;
+    }
+    body.sheet-state-middle .viewer {
+      padding-bottom: 0;
+    }
+    .photo-side {
+      flex: none;
+      height: calc(var(--vh) - 148px);
+      min-height: 300px;
+      max-height: none;
+    }
+    .meta-panel {
+      position: static;
+      max-height: none;
+      border-radius: 0;
+      box-shadow: none;
+      overflow: visible;
+      transition: none;
+    }
+    .meta-panel.sheet-open,
+    .meta-panel.sheet-middle,
+    .meta-panel.sheet-closed {
+      top: auto;
+    }
+    .bottom-sheet-handle {
+      display: none;
+    }
+    #photoCounter {
+      position: static;
+      transform: none;
+      z-index: auto;
+      background: transparent;
+      border: 0;
+      padding: 0;
+      border-radius: 0;
+      color: #888;
+      transition: none;
+    }
+    .filter-popup-modal {
+      inset: auto 8px 8px;
+      max-height: min(620px, calc(var(--vh) - 24px));
+      border: 1px solid #2a2a4e;
+      border-radius: 8px;
+      box-shadow: 0 -8px 24px rgba(0,0,0,0.5);
+    }
+    .filter-popup-close {
+      border-radius: 8px 8px 0 0;
+    }
+    .filter-popup-body {
+      overflow-y: auto;
+      padding-bottom: calc(18px + var(--safe-bottom));
+    }
   }
 
   @media (max-width: 480px) {
@@ -3004,42 +3065,16 @@ setInterval(updateCountdown, 3600000); // refresh hourly
 document.getElementById('calendarCover').src = MEDIA_BASE + 'web/Farther.png';
 
 
-// --- MOBILE BOTTOM SHEET ---
-// On mobile we relocate #descHover into the meta-panel so the description
-// toggle, the orion map, and the photo info live together inside a single
-// fixed-position bottom sheet with three snap points.
 const MOBILE_MQ = window.matchMedia('(max-width: 768px)');
 const sheetEl = document.getElementById('metaPanel');
-const sheetHandleEl = document.getElementById('sheetHandle');
 const descHoverEl = document.getElementById('descHover');
 const trajSectionEl = document.querySelector('.traj-section');
 const photoLinksEl = document.querySelector('.photo-side .photo-links');
-
-let sheetState = 'middle'; // 'open' | 'middle' | 'closed'
-
-function applySheetState(state) {
-  sheetState = state;
-  sheetEl.classList.remove('sheet-open', 'sheet-middle', 'sheet-closed');
-  sheetEl.classList.add('sheet-' + state);
-  document.body.classList.remove('sheet-state-open', 'sheet-state-middle', 'sheet-state-closed');
-  document.body.classList.add('sheet-state-' + state);
-  sheetEl.style.top = '';
-}
-
-function snapPxFor(state) {
-  const vh = window.innerHeight;
-  const handle = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--sheet-handle-h')) || 56;
-  const middleH = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--sheet-middle-h')) || 290;
-  if (state === 'open') return vh * 0.35;
-  if (state === 'middle') return vh - middleH;
-  return vh - handle;
-}
 
 function relocateDescHoverForViewport() {
   if (!descHoverEl) return;
   if (MOBILE_MQ.matches) {
     if (descHoverEl.parentElement !== sheetEl) {
-      // Place it right after the orion map so it's grouped with photo info.
       trajSectionEl.insertAdjacentElement('afterend', descHoverEl);
     }
   } else {
@@ -3049,77 +3084,9 @@ function relocateDescHoverForViewport() {
   }
 }
 
-// --- Drag/snap interaction ---
-let dragStartY = 0;
-let dragStartTop = 0;
-let dragging = false;
-
-function getSheetTopPx() {
-  return sheetEl.getBoundingClientRect().top;
-}
-
-function pickClosestSnap(currentTop) {
-  const targets = ['open', 'middle', 'closed'];
-  let best = 'open';
-  let bestDist = Infinity;
-  for (const s of targets) {
-    const d = Math.abs(currentTop - snapPxFor(s));
-    if (d < bestDist) { bestDist = d; best = s; }
-  }
-  return best;
-}
-
-function onPointerDown(e) {
-  if (!MOBILE_MQ.matches) return;
-  dragging = true;
-  dragStartY = (e.touches ? e.touches[0].clientY : e.clientY);
-  dragStartTop = getSheetTopPx();
-  sheetEl.classList.add('sheet-dragging');
-  // Lock current position so transitions don't fight the drag.
-  sheetEl.style.top = dragStartTop + 'px';
-}
-
-function onPointerMove(e) {
-  if (!dragging) return;
-  const y = (e.touches ? e.touches[0].clientY : e.clientY);
-  const delta = y - dragStartY;
-  const minTop = window.innerHeight * 0.35;
-  const maxTop = snapPxFor('closed');
-  const next = Math.max(minTop, Math.min(maxTop, dragStartTop + delta));
-  sheetEl.style.top = next + 'px';
-  if (e.cancelable) e.preventDefault();
-}
-
-function onPointerUp() {
-  if (!dragging) return;
-  dragging = false;
-  sheetEl.classList.remove('sheet-dragging');
-  const finalTop = getSheetTopPx();
-  const dragDistance = Math.abs(finalTop - dragStartTop);
-  if (dragDistance < 6) {
-    // Treat as tap: cycle through the snaps expanding upward, then dismiss.
-    // closed → middle → open → closed
-    applySheetState(sheetState === 'closed' ? 'middle' : sheetState === 'middle' ? 'open' : 'closed');
-  } else {
-    applySheetState(pickClosestSnap(finalTop));
-  }
-}
-
-if (sheetHandleEl) {
-  sheetHandleEl.addEventListener('touchstart', onPointerDown, { passive: true });
-  sheetHandleEl.addEventListener('touchmove', onPointerMove, { passive: false });
-  sheetHandleEl.addEventListener('touchend', onPointerUp);
-  sheetHandleEl.addEventListener('touchcancel', onPointerUp);
-  sheetHandleEl.addEventListener('mousedown', onPointerDown);
-  window.addEventListener('mousemove', onPointerMove);
-  window.addEventListener('mouseup', onPointerUp);
-}
-
 function syncMobileLayout() {
   relocateDescHoverForViewport();
-  if (MOBILE_MQ.matches) {
-    applySheetState(sheetState);
-  } else {
+  if (!MOBILE_MQ.matches) {
     sheetEl.classList.remove('sheet-open', 'sheet-middle', 'sheet-closed', 'sheet-dragging');
     document.body.classList.remove('sheet-state-open', 'sheet-state-middle', 'sheet-state-closed');
     sheetEl.style.top = '';

--- a/photos.js
+++ b/photos.js
@@ -4898,7 +4898,7 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Glover and Koch Exit the Helicopter",
       "flickr_desc": "NASA astronauts Victor Glover and Christina Koch sit in the doorway of a Navy Seahawk helicopter on the flight deck of USS John P. Murtha, talking with recovery team members.",
-      "enabled": true
+      "enabled": false
     },
     {
       "time": "2026-04-10 22:08:55",
@@ -5000,7 +5000,7 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Glover and Koch Laugh on the Flight Deck",
       "flickr_desc": "NASA astronauts Victor Glover and Christina Koch laugh next to the Navy helicopter on the flight deck of USS John P. Murtha, wearing NASA caps over their orange suits.",
-      "enabled": true
+      "enabled": false
     },
     {
       "time": "2026-04-10 22:10:16",
@@ -6023,7 +6023,7 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": false,
-      "enabled": true
+      "enabled": false
     },
     {
       "time": "2026-04-11 17:32:00",
@@ -6036,7 +6036,7 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": false,
-      "enabled": true
+      "enabled": false
     },
     {
       "time": "2026-04-11 17:35:00",


### PR DESCRIPTION
## Summary
- Simplifies the mobile layout by removing the draggable bottom sheet
- Keeps image descriptions open when navigating between photos
- Adds a mobile description popup
- Hides some confirmed duplicate photo entries:  
Image 301 / 302, 308 / 309, 378 / 353 and 379 / 367