### PR TITLE
Allow voting for less than 5, but still not more

### DIFF
--- a/vote/random/index.html
+++ b/vote/random/index.html
@@ -556,7 +556,7 @@
   }
   function updateCount() {
     $("#count").textContent = String(selected.size);
-    $("#btn-submit").disabled = selected.size !== PICK_LIMIT;
+    $("#btn-submit").disabled = selected.size > PICK_LIMIT || selected.size === 0;
   }
 
   // ====== Lightbox ======


### PR DESCRIPTION
Sometimes the user might not like 5 of the images and only select 4, it makes sense they should be able to do that. I don't think it causes any errors so it should be good.

<img width="150" height="150" alt="image" src="https://github.com/user-attachments/assets/c9641503-d427-4606-8ffd-ea87796cb1a5" />
