### PR TITLE
Add source link to timeline photo metadata panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -478,6 +478,8 @@
   .meta-label { color: #888; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
   .meta-value { color: #bbb; font-size: 13px; margin-top: 2px; word-break: break-word; }
   .meta-value.highlight { color: #4FC3F7; font-weight: 600; }
+  #metaSourceLink { color: #4FC3F7; text-decoration: none; font-size: 12px; }
+  #metaSourceLink:hover { text-decoration: underline; }
   .units-toggle {
     background: none; border: 1px solid #333; border-radius: 4px;
     color: #888; font-size: 10px; font-weight: 600; text-transform: uppercase;
@@ -1335,6 +1337,10 @@
         <div class="meta-label">Settings</div>
         <div class="meta-value" id="metaSettings">—</div>
       </div>
+      <div class="meta-field" id="metaSourceField" style="display:none">
+        <div class="meta-label">Source</div>
+        <div class="meta-value"><a id="metaSourceLink" href="" target="_blank" rel="noopener"></a></div>
+      </div>
       <button class="units-toggle" id="unitsToggle" onclick="toggleUnits()">Show in km</button>
     </div>
     <div class="meta-section" id="descSection" style="display:none">
@@ -1422,7 +1428,41 @@ function getFlickrId(filename) {
 }
 
 
-// --- DATA LOADING ---
+// Returns {url, label} for the source page of a given filename, or null if unknown.
+// Covers Flickr, DVIDS, NASA astronaut photography (eol.jsc.nasa.gov), and NASA Images.
+function getPhotoSource(filename) {
+  const base = filename.replace(/~(large|orig)/i, '').replace(/\.[^.]+$/, '');
+
+  // Flickr 11-digit photo ID (e.g. "55181358952_xyz_o.jpg")
+  const flickrM = filename.match(/^(\d{11})[_-]/);
+  if (flickrM) return { url: 'https://www.flickr.com/photos/nasa2explore/' + flickrM[1], label: 'View on Flickr →' };
+
+  // DVIDS 7-digit numeric (e.g. "9608699.jpg")
+  const dvidsM = filename.match(/^(\d{7})\.jpg$/i);
+  if (dvidsM) return { url: 'https://www.dvidshub.net/image/' + dvidsM[1], label: 'View on DVIDS →' };
+
+  // NASA astronaut photography — uppercase format (e.g. "ART002-E-23107.JPG")
+  const artM = filename.match(/^(ART\d+)-([A-Z])-(\d+)\./i);
+  if (artM) return { url: 'https://eol.jsc.nasa.gov/SearchPhotos/photo.pl?mission=' + artM[1].toUpperCase() + '&roll=' + artM[2].toUpperCase() + '&frame=' + artM[3], label: 'View on NASA →' };
+
+  // NASA astronaut photography — lowercase format (e.g. "art002e014256~large.jpg")
+  const artLowerM = base.match(/^art002e(\d+)$/i);
+  if (artLowerM) return { url: 'https://eol.jsc.nasa.gov/SearchPhotos/photo.pl?mission=ART002&roll=E&frame=' + artLowerM[1], label: 'View on NASA →' };
+
+  // JSC images (e.g. "jsc2026e022251~large.jpg")
+  const jscM = base.match(/^(jsc\d+e\d+)$/i);
+  if (jscM) return { url: 'https://images.nasa.gov/details/' + jscM[1].toLowerCase(), label: 'View on NASA →' };
+
+  // KSC photos (e.g. "KSC-20260401-PH-KLS01_0013.jpg")
+  if (/^KSC-/i.test(base)) return { url: 'https://images.nasa.gov/details/' + base, label: 'View on NASA →' };
+
+  // NHQ photos (e.g. "NHQ20260401_admin_0002.jpg", "nhq202604100018.jpg")
+  if (/^NHQ/i.test(base)) return { url: 'https://images.nasa.gov/details/' + base, label: 'View on NASA →' };
+
+  return null;
+}
+
+
 // These are populated by loadPhotoData() from the PHOTO_DATA global (photos.js).
 let PHOTO_TITLES = {};   // photoId → display title
 let PHOTO_DESCS = {};    // photoId → long description (for hover tooltip)
@@ -2363,6 +2403,7 @@ function updatePhoto() {
     document.getElementById('metaSettings').textContent = '—';
     document.getElementById('photoTitleRow').style.display = 'none';
     document.getElementById('descSection').style.display = 'none';
+    document.getElementById('metaSourceField').style.display = 'none';
     renderTimeline();
     return;
   }
@@ -2423,6 +2464,16 @@ function updatePhoto() {
   }
   document.getElementById('metaCamera').textContent = photo.cam;
   document.getElementById('metaSettings').textContent = photo.set;
+  const photoSrc = getPhotoSource(photo.f);
+  const srcField = document.getElementById('metaSourceField');
+  const srcLink = document.getElementById('metaSourceLink');
+  if (photoSrc) {
+    srcLink.href = photoSrc.url;
+    srcLink.textContent = photoSrc.label;
+    srcField.style.display = '';
+  } else {
+    srcField.style.display = 'none';
+  }
   document.getElementById('photoCounter').textContent = `${currentPhotoIdx + 1} / ${filteredPhotos.length}`;
   if (photo.desc) {
     document.getElementById('descSection').style.display = '';

--- a/index.html
+++ b/index.html
@@ -1430,19 +1430,22 @@ function getFlickrId(filename) {
 
 // Returns {url, label} for the source page of a given filename, or null if unknown.
 // Covers Flickr, DVIDS, NASA astronaut photography (eol.jsc.nasa.gov), and NASA Images.
+// All pattern matching runs against `base` (extension and ~large/~orig suffix stripped)
+// so that hypothetical future variants like "9608699~large.jpg" or "ART002-E-23107~large.JPG"
+// are handled consistently.
 function getPhotoSource(filename) {
   const base = filename.replace(/~(large|orig)/i, '').replace(/\.[^.]+$/, '');
 
-  // Flickr 11-digit photo ID (e.g. "55181358952_xyz_o.jpg")
-  const flickrM = filename.match(/^(\d{11})[_-]/);
+  // Flickr 11-digit photo ID (e.g. "55181358952_xyz_o")
+  const flickrM = base.match(/^(\d{11})[_-]/);
   if (flickrM) return { url: 'https://www.flickr.com/photos/nasa2explore/' + flickrM[1], label: 'View on Flickr →' };
 
-  // DVIDS 7-digit numeric (e.g. "9608699.jpg")
-  const dvidsM = filename.match(/^(\d{7})\.jpg$/i);
+  // DVIDS 7-digit numeric (e.g. "9608699")
+  const dvidsM = base.match(/^(\d{7})$/);
   if (dvidsM) return { url: 'https://www.dvidshub.net/image/' + dvidsM[1], label: 'View on DVIDS →' };
 
-  // NASA astronaut photography — uppercase format (e.g. "ART002-E-23107.JPG")
-  const artM = filename.match(/^(ART\d+)-([A-Z])-(\d+)\./i);
+  // NASA astronaut photography — uppercase format (e.g. "ART002-E-23107")
+  const artM = base.match(/^(ART\d+)-([A-Z])-(\d+)$/i);
   if (artM) return { url: 'https://eol.jsc.nasa.gov/SearchPhotos/photo.pl?mission=' + artM[1].toUpperCase() + '&roll=' + artM[2].toUpperCase() + '&frame=' + artM[3], label: 'View on NASA →' };
 
   // NASA astronaut photography — lowercase format (e.g. "art002e014256~large.jpg")


### PR DESCRIPTION
NOTE I HAVE NOT THOROUGHLY TESTED THIS OR REVIEWED THE UX. I made this from github mobile using Copilot so I have not ran the changes. Maintainer please review and let me know if I need to update my fork to update this pr for any changes. Also test the UX changes, I wasn't strict on directions for the instruction. 

This pull request adds a new feature to display the source of each photo in the Artemis II Photo Timeline, when available. It introduces logic to detect the source platform from the photo filename and provides a direct link to view the photo on its original site (e.g., Flickr, DVIDS, NASA). The UI is updated to show this source link in the photo metadata section when applicable.

**Photo Source Attribution Feature:**

* Added the `getPhotoSource` function to identify the source platform (Flickr, DVIDS, NASA, etc.) from a photo filename and return the appropriate URL and label for linking.
* Updated the photo metadata UI by adding a new `metaSourceField` element and associated styles for displaying the source link. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R1340-R1343) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R481-R482)
* Modified the photo details rendering logic to show or hide the source field and link based on whether a source can be determined for the current photo.
* Ensured the source field is hidden when no photo is selected or when the source cannot be determined.