### PR TITLE
Add era and NASA center filter buttons to the viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1251,6 +1251,13 @@
   <button class="filter-btn cam-filter" data-cam="gopro" title="GoPro exterior camera mounted on Orion">GoPro</button>
   <button class="filter-btn cam-filter" data-cam="iphone" title="Crew iPhone 17 Pro Max on Orion">iPhone</button>
   <span class="filter-sep">|</span>
+  <button class="filter-btn center-filter" data-center="KSC"  title="Kennedy Space Center">KSC</button>
+  <button class="filter-btn center-filter" data-center="JSC"  title="Johnson Space Center">JSC</button>
+  <button class="filter-btn center-filter" data-center="MSFC" title="Marshall Space Flight Center">MSFC</button>
+  <button class="filter-btn center-filter" data-center="SSC"  title="Stennis Space Center">SSC</button>
+  <button class="filter-btn center-filter" data-center="MAF"  title="Michoud Assembly Facility">MAF</button>
+  <button class="filter-btn center-filter" data-center="HQ"   title="NASA Headquarters">HQ</button>
+  <span class="filter-sep">|</span>
   <button class="filter-btn" data-filter="videos">Videos</button>
   <span class="filter-sep">|</span>
   <button class="filter-btn" id="muteBtn" title="Toggle mission audio"><span class="audio-checkbox" aria-hidden="true"></span><span>PLAY AUDIO</span></button>
@@ -1434,7 +1441,7 @@ let AUDIO = [];
 function loadPhotoData() {
   const data = PHOTO_DATA;
   data.photos.filter(p => p.enabled !== false).forEach(p => {
-    const entry = {t:edt(p.time),f:p.file,p:p.photographer,loc:p.location,cam:p.camera,set:p.settings,sc:!!p.spacecraft,b:p.batch||0};
+    const entry = {t:edt(p.time),f:p.file,p:p.photographer,loc:p.location,cam:p.camera,set:p.settings,sc:!!p.spacecraft,b:p.batch||0,center:p.center||''};
     // Camera ID for filter buttons — use explicit camera_id from data if present,
     // otherwise derive from camera string (z9, gopro, iphone)
     if (p.camera_id) entry.cid = p.camera_id;
@@ -2773,20 +2780,33 @@ function clearAllFilters() {
   document.querySelectorAll('[data-filter]').forEach(b => b.classList.remove('active'));
   document.querySelectorAll('[data-crew]').forEach(b => b.classList.remove('active'));
   document.querySelectorAll('[data-cam]').forEach(b => b.classList.remove('active'));
+  document.querySelectorAll('[data-center]').forEach(b => b.classList.remove('active'));
 }
 
-// Apply camera multi-select filter (union of selected camera types).
-// Returns true if any filter is active.
+// Apply multi-select filters (camera + NASA center).
+// Within each group: OR. Across groups: AND.
+// Returns true if any multi-select filter is active.
 function applyMultiFilter() {
   const activeCams = Array.from(document.querySelectorAll('[data-cam].active')).map(b => b.dataset.cam);
-  if (activeCams.length === 0) return false;
+  const activeCenters = Array.from(document.querySelectorAll('[data-center].active')).map(b => b.dataset.center);
+  if (activeCams.length === 0 && activeCenters.length === 0) return false;
+
   filteredPhotos = PHOTOS.filter(p => {
-    for (const c of activeCams) {
-      if (c === 'gopro' && p.cam && p.cam.includes('HERO')) return true;
-      if (c === 'iphone' && p.cam && p.cam.includes('iPhone')) return true;
-      if (c !== 'gopro' && c !== 'iphone' && p.cid === c) return true;
+    // Camera group (OR within group)
+    if (activeCams.length > 0) {
+      let camMatch = false;
+      for (const c of activeCams) {
+        if (c === 'gopro' && p.cam && p.cam.includes('HERO'))   { camMatch = true; break; }
+        if (c === 'iphone' && p.cam && p.cam.includes('iPhone')) { camMatch = true; break; }
+        if (c !== 'gopro' && c !== 'iphone' && p.cid === c)      { camMatch = true; break; }
+      }
+      if (!camMatch) return false;
     }
-    return false;
+    // Center group (OR within group)
+    if (activeCenters.length > 0) {
+      if (!activeCenters.includes(p.center)) return false;
+    }
+    return true;
   });
   return true;
 }
@@ -2810,6 +2830,24 @@ document.querySelectorAll('[data-cam]').forEach(btn => {
     // Clear non-multi-select filters
     document.querySelectorAll('[data-filter]').forEach(b => b.classList.remove('active'));
       // Toggle this camera filter
+    this.classList.toggle('active');
+    const anyActive = applyMultiFilter();
+    if (!anyActive) {
+      document.querySelector('[data-filter="all"]').classList.add('active');
+      filteredPhotos = PHOTOS;
+    }
+    currentPhotoIdx = 0;
+    viewStart = T_START; viewEnd = T_END;
+    updatePhoto();
+  });
+});
+
+// NASA center filters: multi-select among themselves. Same interaction model
+// as camera filters — clicking one clears the exclusive "data-filter" group
+// and stacks (AND) with any active camera filters via applyMultiFilter.
+document.querySelectorAll('[data-center]').forEach(btn => {
+  btn.addEventListener('click', function() {
+    document.querySelectorAll('[data-filter]').forEach(b => b.classList.remove('active'));
     this.classList.toggle('active');
     const anyActive = applyMultiFilter();
     if (!anyActive) {
@@ -2950,6 +2988,11 @@ function syncFilterPopupState() {
     const btn = document.querySelector('[data-cam="' + input.dataset.camInput + '"]');
     input.checked = !!(btn && btn.classList.contains('active'));
   });
+  // NASA CENTERS
+  document.querySelectorAll('input[data-center-input]').forEach(input => {
+    const btn = document.querySelector('[data-center="' + input.dataset.centerInput + '"]');
+    input.checked = !!(btn && btn.classList.contains('active'));
+  });
   // MEDIA TYPE
   const videosBox = document.getElementById('filterVideosOnly');
   if (videosBox) videosBox.checked = (dfValue === 'videos');
@@ -2969,6 +3012,16 @@ function updateFilterDropdownLabel() {
   if (activeCams.length) {
     parts.push(activeCams.length + ' Camera' + (activeCams.length > 1 ? 's' : ''));
   }
+  const activeCenters = Array.from(document.querySelectorAll('[data-center].active'));
+  if (activeCenters.length) {
+    // For 1–3 selected centers show their codes inline (e.g. "KSC/JSC");
+    // otherwise abbreviate to "4 Centers" to keep the label short.
+    if (activeCenters.length <= 3) {
+      parts.push(activeCenters.map(b => b.dataset.center).join('/'));
+    } else {
+      parts.push(activeCenters.length + ' Centers');
+    }
+  }
   label.textContent = parts.length ? ('Showing ' + parts.join(' • ')) : 'Showing All Photos and Videos';
 }
 
@@ -2984,6 +3037,8 @@ document.addEventListener('change', e => {
     btn = document.querySelector('[data-filter="' + t.value + '"]');
   } else if (t.matches('input[data-cam-input]')) {
     btn = document.querySelector('[data-cam="' + t.dataset.camInput + '"]');
+  } else if (t.matches('input[data-center-input]')) {
+    btn = document.querySelector('[data-center="' + t.dataset.centerInput + '"]');
   } else if (t.id === 'filterVideosOnly') {
     btn = document.querySelector(t.checked ? '[data-filter="videos"]' : '[data-filter="all"]');
   } else {
@@ -3227,6 +3282,33 @@ window.addEventListener('resize', syncMobileLayout);
       <label class="filter-option">
         <input type="checkbox" data-cam-input="iphone">
         <span>iPhone <em>crew iPhone 17 Pro Max</em></span>
+      </label>
+    </div>
+    <div class="filter-section">
+      <h4>NASA Center</h4>
+      <label class="filter-option">
+        <input type="checkbox" data-center-input="KSC">
+        <span>KSC <em>Kennedy Space Center</em></span>
+      </label>
+      <label class="filter-option">
+        <input type="checkbox" data-center-input="JSC">
+        <span>JSC <em>Johnson Space Center</em></span>
+      </label>
+      <label class="filter-option">
+        <input type="checkbox" data-center-input="MSFC">
+        <span>MSFC <em>Marshall Space Flight Center</em></span>
+      </label>
+      <label class="filter-option">
+        <input type="checkbox" data-center-input="SSC">
+        <span>SSC <em>Stennis Space Center</em></span>
+      </label>
+      <label class="filter-option">
+        <input type="checkbox" data-center-input="MAF">
+        <span>MAF <em>Michoud Assembly Facility</em></span>
+      </label>
+      <label class="filter-option">
+        <input type="checkbox" data-center-input="HQ">
+        <span>HQ <em>NASA Headquarters</em></span>
       </label>
     </div>
     <div class="filter-section">

--- a/index.html
+++ b/index.html
@@ -1251,6 +1251,11 @@
   <button class="filter-btn cam-filter" data-cam="gopro" title="GoPro exterior camera mounted on Orion">GoPro</button>
   <button class="filter-btn cam-filter" data-cam="iphone" title="Crew iPhone 17 Pro Max on Orion">iPhone</button>
   <span class="filter-sep">|</span>
+  <button class="filter-btn era-filter" data-era="pre-flight-hardware" title="Flight hardware development — SLS, Orion, integration, pad ops">Hardware</button>
+  <button class="filter-btn era-filter" data-era="pre-flight-training" title="Crew training — NBL, simulators, T-38, geology, suit fit">Training</button>
+  <button class="filter-btn era-filter" data-era="mission"             title="Mission week — March 27 to April 11, 2026">Mission</button>
+  <button class="filter-btn era-filter" data-era="post-mission"        title="Post-flight — recovery, debrief, welcome home">Post-Mission</button>
+  <span class="filter-sep">|</span>
   <button class="filter-btn center-filter" data-center="KSC"  title="Kennedy Space Center">KSC</button>
   <button class="filter-btn center-filter" data-center="JSC"  title="Johnson Space Center">JSC</button>
   <button class="filter-btn center-filter" data-center="MSFC" title="Marshall Space Flight Center">MSFC</button>
@@ -1441,7 +1446,7 @@ let AUDIO = [];
 function loadPhotoData() {
   const data = PHOTO_DATA;
   data.photos.filter(p => p.enabled !== false).forEach(p => {
-    const entry = {t:edt(p.time),f:p.file,p:p.photographer,loc:p.location,cam:p.camera,set:p.settings,sc:!!p.spacecraft,b:p.batch||0,center:p.center||''};
+    const entry = {t:edt(p.time),f:p.file,p:p.photographer,loc:p.location,cam:p.camera,set:p.settings,sc:!!p.spacecraft,b:p.batch||0,center:p.center||'',era:p.era||'unknown'};
     // Camera ID for filter buttons — use explicit camera_id from data if present,
     // otherwise derive from camera string (z9, gopro, iphone)
     if (p.camera_id) entry.cid = p.camera_id;
@@ -2781,15 +2786,17 @@ function clearAllFilters() {
   document.querySelectorAll('[data-crew]').forEach(b => b.classList.remove('active'));
   document.querySelectorAll('[data-cam]').forEach(b => b.classList.remove('active'));
   document.querySelectorAll('[data-center]').forEach(b => b.classList.remove('active'));
+  document.querySelectorAll('[data-era]').forEach(b => b.classList.remove('active'));
 }
 
-// Apply multi-select filters (camera + NASA center).
+// Apply multi-select filters (camera + NASA center + era).
 // Within each group: OR. Across groups: AND.
 // Returns true if any multi-select filter is active.
 function applyMultiFilter() {
   const activeCams = Array.from(document.querySelectorAll('[data-cam].active')).map(b => b.dataset.cam);
   const activeCenters = Array.from(document.querySelectorAll('[data-center].active')).map(b => b.dataset.center);
-  if (activeCams.length === 0 && activeCenters.length === 0) return false;
+  const activeEras = Array.from(document.querySelectorAll('[data-era].active')).map(b => b.dataset.era);
+  if (activeCams.length === 0 && activeCenters.length === 0 && activeEras.length === 0) return false;
 
   filteredPhotos = PHOTOS.filter(p => {
     // Camera group (OR within group)
@@ -2805,6 +2812,10 @@ function applyMultiFilter() {
     // Center group (OR within group)
     if (activeCenters.length > 0) {
       if (!activeCenters.includes(p.center)) return false;
+    }
+    // Era group (OR within group)
+    if (activeEras.length > 0) {
+      if (!activeEras.includes(p.era)) return false;
     }
     return true;
   });
@@ -2846,6 +2857,24 @@ document.querySelectorAll('[data-cam]').forEach(btn => {
 // as camera filters — clicking one clears the exclusive "data-filter" group
 // and stacks (AND) with any active camera filters via applyMultiFilter.
 document.querySelectorAll('[data-center]').forEach(btn => {
+  btn.addEventListener('click', function() {
+    document.querySelectorAll('[data-filter]').forEach(b => b.classList.remove('active'));
+    this.classList.toggle('active');
+    const anyActive = applyMultiFilter();
+    if (!anyActive) {
+      document.querySelector('[data-filter="all"]').classList.add('active');
+      filteredPhotos = PHOTOS;
+    }
+    currentPhotoIdx = 0;
+    viewStart = T_START; viewEnd = T_END;
+    updatePhoto();
+  });
+});
+
+// Era filters: same pattern. Hardware / Training / Mission / Post-Mission.
+// All multi-select; ANDs with camera and center filters; clears the
+// exclusive data-filter group when clicked.
+document.querySelectorAll('[data-era]').forEach(btn => {
   btn.addEventListener('click', function() {
     document.querySelectorAll('[data-filter]').forEach(b => b.classList.remove('active'));
     this.classList.toggle('active');
@@ -2993,6 +3022,11 @@ function syncFilterPopupState() {
     const btn = document.querySelector('[data-center="' + input.dataset.centerInput + '"]');
     input.checked = !!(btn && btn.classList.contains('active'));
   });
+  // ERAS
+  document.querySelectorAll('input[data-era-input]').forEach(input => {
+    const btn = document.querySelector('[data-era="' + input.dataset.eraInput + '"]');
+    input.checked = !!(btn && btn.classList.contains('active'));
+  });
   // MEDIA TYPE
   const videosBox = document.getElementById('filterVideosOnly');
   if (videosBox) videosBox.checked = (dfValue === 'videos');
@@ -3022,6 +3056,21 @@ function updateFilterDropdownLabel() {
       parts.push(activeCenters.length + ' Centers');
     }
   }
+  const activeEras = Array.from(document.querySelectorAll('[data-era].active'));
+  if (activeEras.length) {
+    // Compact era labels for the dropdown — Hardware / Training / Mission / Post
+    const ERA_SHORT = {
+      'pre-flight-hardware': 'Hardware',
+      'pre-flight-training': 'Training',
+      'mission': 'Mission',
+      'post-mission': 'Post',
+    };
+    if (activeEras.length <= 3) {
+      parts.push(activeEras.map(b => ERA_SHORT[b.dataset.era] || b.dataset.era).join('/'));
+    } else {
+      parts.push(activeEras.length + ' Eras');
+    }
+  }
   label.textContent = parts.length ? ('Showing ' + parts.join(' • ')) : 'Showing All Photos and Videos';
 }
 
@@ -3039,6 +3088,8 @@ document.addEventListener('change', e => {
     btn = document.querySelector('[data-cam="' + t.dataset.camInput + '"]');
   } else if (t.matches('input[data-center-input]')) {
     btn = document.querySelector('[data-center="' + t.dataset.centerInput + '"]');
+  } else if (t.matches('input[data-era-input]')) {
+    btn = document.querySelector('[data-era="' + t.dataset.eraInput + '"]');
   } else if (t.id === 'filterVideosOnly') {
     btn = document.querySelector(t.checked ? '[data-filter="videos"]' : '[data-filter="all"]');
   } else {
@@ -3309,6 +3360,25 @@ window.addEventListener('resize', syncMobileLayout);
       <label class="filter-option">
         <input type="checkbox" data-center-input="HQ">
         <span>HQ <em>NASA Headquarters</em></span>
+      </label>
+    </div>
+    <div class="filter-section">
+      <h4>Mission Era</h4>
+      <label class="filter-option">
+        <input type="checkbox" data-era-input="pre-flight-hardware">
+        <span>Hardware <em>SLS, Orion, integration, pad ops</em></span>
+      </label>
+      <label class="filter-option">
+        <input type="checkbox" data-era-input="pre-flight-training">
+        <span>Training <em>NBL, simulators, T-38, geology, suit fit</em></span>
+      </label>
+      <label class="filter-option">
+        <input type="checkbox" data-era-input="mission">
+        <span>Mission <em>March 27 to April 11, 2026</em></span>
+      </label>
+      <label class="filter-option">
+        <input type="checkbox" data-era-input="post-mission">
+        <span>Post-Mission <em>Recovery, debrief, welcome home</em></span>
       </label>
     </div>
     <div class="filter-section">


### PR DESCRIPTION
Builds on #40 (schema additions). Adds two new groups of multi-select filter buttons to the controls row in `index.html`, mirroring your existing camera-filter pattern exactly.

## What this PR adds

**Era filters** — four buttons reading the new `era` field:

```
[Hardware] [Training] [Mission] [Post-Mission]
```

- `Hardware` → entries with `era: "pre-flight-hardware"`
- `Training` → entries with `era: "pre-flight-training"`
- `Mission` → entries with `era: "mission"` (all 519 of your originals)
- `Post-Mission` → entries with `era: "post-mission"`

**NASA center filters** — six buttons reading the new `center` field:

```
[KSC] [JSC] [MSFC] [SSC] [MAF] [HQ]
```

## How they behave

- **Multi-select within each group** — clicking `KSC` + `JSC` shows entries from either
- **AND across groups** — `Training` + `JSC` = JSC training entries only
- **AND with the existing camera filters** — `Hardware` + `Z9` = Z9-shot hardware photos
- Clicking any of them clears the exclusive `data-filter` group (`All / Crew Photos Only / etc.`), same exclusivity rule your camera filters use

## Mobile

The bottom-sheet filter popup gets two matching sections (`Mission Era` and `NASA Center`) above the existing `Media Type` section. Same multi-select checkbox pattern.

## Code shape

All changes confined to `index.html`. Extends the existing `applyMultiFilter()` to handle two new orthogonal groups. Adds parallel click handlers for `[data-era]` and `[data-center]` selectors. The new buttons reuse the existing `.filter-btn` CSS class.

## Behaviour on the current data

With just your 519 entries, clicking the era buttons:
- `Mission` → all 489 enabled photos (which is everything)
- `Hardware` / `Training` / `Post-Mission` → 0 (you don't have any of those yet)

That's correct behaviour — the filters are wired and ready for any future content that lands with those era values.

## Out of scope

- ❌ No schema changes (those landed in #40)
- ❌ No new entries
- ❌ No mini-timeline or anything else from my fork — that's a separate PR

Closes a logical pairing with the schema fields from #40: a place to display them.
