### PR TITLE
Add local-only acquisition pipeline + admin Pending tab (optional, largest)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,16 @@ photos.json
 photos2.js
 photos22.js
 
+# Local meta-doc tracking files added by John to this fork (not for upstream)
+NEW_FILES_LOCAL.md
+
+# tools/import/ run output — state, queue, staged files, logs
+# (source files in tools/import/ ARE tracked; only run-output is ignored)
+tools/import/state.json
+tools/import/inbox.json
+tools/import/staging/
+tools/import/log/
+
 # Source reference materials (not part of the site)
 artemis-ii-overview-timeline-public-final.pdf
 artemis-ii-timeline.jsx

--- a/admin.html
+++ b/admin.html
@@ -378,6 +378,274 @@ a:hover { text-decoration: underline; }
   padding: 20px 24px;
 }
 
+/* -----------------------------------------------------------
+   Pending tab (acquisition pipeline inbox)
+   ----------------------------------------------------------- */
+.pending-pane.hidden { display: none; }
+
+.pending-banner {
+  margin: 12px 24px;
+  padding: 12px 14px;
+  border-radius: var(--radius);
+  background: rgba(239, 83, 80, 0.1);
+  border: 1px solid var(--danger);
+  color: var(--danger);
+  font-size: 13px;
+  line-height: 1.5;
+}
+.pending-banner code {
+  background: rgba(0,0,0,0.3);
+  padding: 2px 6px;
+  border-radius: 3px;
+  color: #ffb;
+  font-size: 12px;
+}
+
+.pending-toolbar {
+  padding: 12px 24px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.pending-sync, .pending-bulk {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.pending-card {
+  display: flex;
+  gap: 14px;
+  padding: 14px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  align-items: flex-start;
+  transition: background 0.15s, border-color 0.15s;
+  position: relative;
+}
+.pending-card:hover { background: var(--bg-card-hover); }
+.pending-card.quality-red    { border-left: 4px solid var(--danger); }
+.pending-card.quality-yellow { border-left: 4px solid var(--warning); }
+.pending-card.quality-green  { border-left: 4px solid var(--enabled); }
+
+.pending-thumb {
+  width: 200px;
+  min-width: 200px;
+  height: 140px;
+  object-fit: cover;
+  border-radius: 4px;
+  background: #1a1a2e;
+  cursor: pointer;
+}
+
+.pending-select {
+  display: flex;
+  align-items: flex-start;
+  padding-top: 6px;
+}
+.pending-select input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.pending-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.pending-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.pending-title-row input {
+  flex: 1;
+  background: var(--bg-input);
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--text-bright);
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 4px 8px;
+  outline: none;
+}
+.pending-title-row input:focus,
+.pending-title-row input:hover { border-color: var(--accent); }
+
+.pending-badges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+}
+.pending-badge {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  white-space: nowrap;
+}
+.pending-badge.conf-high   { background: rgba(76,175,80,0.2); color: #81c784; }
+.pending-badge.conf-medium { background: rgba(255,179,0,0.2); color: #ffd54f; }
+.pending-badge.conf-low    { background: rgba(120,120,120,0.2); color: #aaa; }
+.pending-badge.qual-green  { background: rgba(76,175,80,0.15); color: #81c784; }
+.pending-badge.qual-yellow { background: rgba(255,179,0,0.15); color: #ffd54f; }
+.pending-badge.qual-red    { background: rgba(239,83,80,0.18); color: #ef9a9a; }
+.pending-badge.source      { background: rgba(79,195,247,0.15); color: var(--accent); }
+.pending-badge.center      { background: rgba(123,104,238,0.18); color: #b0a0ff; }
+
+.pending-meta-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.pending-field {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+}
+.pending-field label {
+  color: var(--text-dim);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+}
+.pending-field input,
+.pending-field select {
+  background: var(--bg-input);
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 12px;
+  padding: 3px 6px;
+  outline: none;
+}
+.pending-field input:hover,
+.pending-field input:focus,
+.pending-field select:hover,
+.pending-field select:focus { border-color: var(--accent); }
+.pending-field input.short { width: 150px; }
+.pending-field input.med   { width: 200px; }
+.pending-field input.time-input { width: 200px; color-scheme: dark; }
+.pending-field select { width: 170px; }
+
+.pending-desc {
+  font-size: 12px;
+  color: var(--text-dim);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  max-height: 60px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+.pending-desc.expanded { max-height: none; }
+
+.pending-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+.pending-actions button {
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  background: var(--bg-input);
+  color: var(--text);
+  cursor: pointer;
+  font-weight: 600;
+  font-family: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+.pending-actions button.promote  { background: var(--enabled); color: #000; }
+.pending-actions button.reject   { background: var(--danger);  color: #fff; }
+.pending-actions button.view     { background: transparent;    border-color: var(--border); }
+.pending-actions button.promote:hover { background: #66bb6a; }
+.pending-actions button.reject:hover  { background: #c62828; }
+
+.pending-empty {
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 13px;
+  padding: 40px 24px;
+  font-style: italic;
+}
+
+/* Era-colored highlights for classifier matches inside text. */
+.pending-desc mark,
+.pending-title-matches mark {
+  padding: 0 3px;
+  border-radius: 3px;
+  font-weight: 600;
+  cursor: help;
+  background: rgba(255, 235, 100, 0.25);   /* fallback color */
+  color: inherit;
+}
+.pending-desc mark.era-pre-flight-hardware,
+.pending-title-matches mark.era-pre-flight-hardware {
+  background: rgba(123, 104, 238, 0.32);
+  color: #d0c0ff;
+}
+.pending-desc mark.era-pre-flight-training,
+.pending-title-matches mark.era-pre-flight-training {
+  background: rgba(76, 175, 80, 0.32);
+  color: #c8e6c9;
+}
+.pending-desc mark.era-mission,
+.pending-title-matches mark.era-mission {
+  background: rgba(255, 179, 0, 0.32);
+  color: #ffe082;
+}
+.pending-desc mark.era-post-mission,
+.pending-title-matches mark.era-post-mission {
+  background: rgba(239, 83, 80, 0.32);
+  color: #ffcdd2;
+}
+
+.pending-title-matches {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 2px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.pending-title-matches strong {
+  color: var(--text-dim);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-right: 4px;
+}
+
+.pending-quality-detail {
+  font-size: 10px;
+  color: var(--warning);
+  margin-top: 2px;
+  line-height: 1.4;
+}
+.pending-quality-detail strong { color: var(--text-dim); margin-right: 4px; }
+.pending-card.quality-red .pending-quality-detail { color: var(--danger); }
+
 /* Responsive */
 @media (max-width: 700px) {
   .header { padding: 12px 14px; }
@@ -409,6 +677,7 @@ a:hover { text-decoration: underline; }
   <div class="tabs">
     <button class="tab-btn active" data-tab="photos" onclick="switchTab('photos')">Photos / Videos</button>
     <button class="tab-btn" data-tab="audio" onclick="switchTab('audio')">Audio</button>
+    <button class="tab-btn" data-tab="pending" onclick="switchTab('pending')">Pending <span id="pending-tab-count" style="opacity:0.7"></span></button>
   </div>
   <input type="text" class="search-input" id="search" placeholder="Search title, filename, photographer, location...">
   <div class="filters" id="filters">
@@ -424,6 +693,28 @@ a:hover { text-decoration: underline; }
 
 <div class="card-list" id="photo-list"></div>
 <div class="card-list hidden" id="audio-list"></div>
+
+<!-- Pending tab: review queue from the acquisition pipeline's inbox.json,
+     served via the local sidecar (node tools/import/server.js). -->
+<div class="pending-pane hidden" id="pending-pane">
+  <div class="pending-banner" id="pending-banner" style="display:none"></div>
+  <div class="pending-toolbar">
+    <div class="pending-sync">
+      <input type="text" class="search-input" id="pending-query" placeholder='Optional query — e.g. "Artemis II SLS"' style="min-width:260px">
+      <input type="text" class="search-input" id="pending-centers" placeholder="Centers (e.g. KSC,JSC)" style="max-width:180px">
+      <input type="number" class="search-input" id="pending-limit" value="20" min="1" max="500" style="max-width:80px" title="Max new candidates this run">
+      <button class="save-btn" onclick="runSync()" id="pending-run-btn">Run Sync</button>
+    </div>
+    <div class="pending-bulk">
+      <button class="save-btn" style="background:var(--enabled)" onclick="promoteSelected()" id="pending-promote-btn">Promote Selected (<span id="pending-promote-count">0</span>)</button>
+      <button class="save-btn" style="background:var(--danger);color:#fff" onclick="rejectSelected()" id="pending-reject-btn">Reject Selected (<span id="pending-reject-count">0</span>)</button>
+      <button class="save-btn" style="background:transparent;color:var(--text);border:1px solid var(--border)" onclick="loadPending()">Refresh</button>
+      <a class="back-link" href="tools/import/EDITORIAL.md" target="_blank" rel="noopener" style="margin-left:auto">Editorial principles ↗</a>
+    </div>
+  </div>
+  <div class="card-list" id="pending-list" style="padding-top:0"></div>
+</div>
+
 <div class="count-label" id="count-label"></div>
 
 <script>
@@ -481,7 +772,9 @@ function switchTab(tab) {
     b.classList.toggle('active', b.dataset.tab === tab));
   document.getElementById('photo-list').classList.toggle('hidden', tab !== 'photos');
   document.getElementById('audio-list').classList.toggle('hidden', tab !== 'audio');
+  document.getElementById('pending-pane').classList.toggle('hidden', tab !== 'pending');
   updateCountLabel();
+  if (tab === 'pending') loadPending();
 }
 
 // Filters
@@ -791,6 +1084,357 @@ function esc(s) {
   const d = document.createElement('div');
   d.textContent = s;
   return d.innerHTML.replace(/"/g, '&quot;');
+}
+
+// ============================================================================
+// PENDING TAB — talks to the local sidecar (tools/import/server.js) for the
+// acquisition pipeline's review queue. Sidecar runs on 127.0.0.1:8001 by
+// default; if it isn't running we show a banner explaining how to start it.
+// ============================================================================
+
+const SIDECAR_URL = 'http://127.0.0.1:8001';
+let pendingCandidates = [];                  // last-loaded inbox snapshot
+const pendingSelected = new Set();           // source_ids checked for bulk ops
+const pendingEdits = new Map();              // source_id -> { title, time, ... }
+
+async function sidecarFetch(pathname, options) {
+  const res = await fetch(SIDECAR_URL + pathname, options);
+  if (!res.ok) {
+    let body = null;
+    try { body = await res.json(); } catch (e) { /* */ }
+    const msg = body && body.error
+        ? `${res.status} ${body.error}${body.detail ? ' — ' + body.detail : ''}`
+        : `${res.status} ${res.statusText}`;
+    throw new Error(msg);
+  }
+  return res.json();
+}
+
+function showPendingBanner(html) {
+  const b = document.getElementById('pending-banner');
+  b.innerHTML = html;
+  b.style.display = html ? 'block' : 'none';
+}
+
+function clearPendingBanner() {
+  showPendingBanner('');
+}
+
+async function loadPending() {
+  pendingSelected.clear();
+  pendingEdits.clear();
+  document.getElementById('pending-list').innerHTML =
+      '<div class="pending-empty">Loading from sidecar…</div>';
+  try {
+    const data = await sidecarFetch('/inbox');
+    pendingCandidates = data.candidates || [];
+    clearPendingBanner();
+    renderPending();
+  } catch (err) {
+    pendingCandidates = [];
+    document.getElementById('pending-list').innerHTML = '';
+    showPendingBanner(
+      'Sidecar offline. Start it with: <code>node tools/import/server.js</code> ' +
+      '<br>Then click <strong>Refresh</strong> above. ' +
+      '<br><br>Reason: ' + esc(err.message)
+    );
+    updatePendingCount();
+  }
+}
+
+function updatePendingCount() {
+  document.getElementById('pending-tab-count').textContent =
+      pendingCandidates.length ? `(${pendingCandidates.length})` : '';
+  document.getElementById('pending-promote-count').textContent = pendingSelected.size;
+  document.getElementById('pending-reject-count').textContent  = pendingSelected.size;
+}
+
+function renderPending() {
+  const list = document.getElementById('pending-list');
+  if (pendingCandidates.length === 0) {
+    list.innerHTML =
+        '<div class="pending-empty">Inbox is empty. Use <strong>Run Sync</strong> above to discover new candidates.</div>';
+    updatePendingCount();
+    return;
+  }
+  list.innerHTML = pendingCandidates.map(renderPendingCard).join('');
+  updatePendingCount();
+}
+
+// Wrap classifier-matched substrings inside one of the candidate's text
+// fields with <mark> elements. The returned string is HTML-escaped except
+// for the mark wrappers; safe to inject via innerHTML.
+//
+// Overlapping matches are resolved by "first one wins" — sort by start
+// index, skip anything whose start lies inside the previous mark.
+function highlightField(text, evidence, sourceField) {
+  if (!text) return '';
+  const matches = ((evidence && evidence.era_matches) || [])
+      .filter(m => m.kind === 'keyword' && m.sourceField === sourceField && typeof m.index === 'number')
+      .sort((a, b) => a.index - b.index || (b.excerpt || '').length - (a.excerpt || '').length);
+
+  if (matches.length === 0) return esc(text);
+
+  let out = '';
+  let cursor = 0;
+  for (const m of matches) {
+    const start = m.index;
+    const end = start + (m.excerpt || '').length;
+    if (start < cursor) continue;                  // overlap with prior mark — skip
+    if (start > cursor) out += esc(text.slice(cursor, start));
+    const matched = text.slice(start, end);
+    const title = `matched pattern: ${m.pattern || m.excerpt}  ·  era: ${m.era}`;
+    out += `<mark class="era-${esc(m.era)}" title="${esc(title)}">${esc(matched)}</mark>`;
+    cursor = end;
+  }
+  if (cursor < text.length) out += esc(text.slice(cursor));
+  return out;
+}
+
+// Collect the unique matched keywords for a given field, with their era.
+// Used for the "matched in title:" chip strip.
+function uniqueMatchesForField(evidence, sourceField) {
+  const seen = new Set();
+  const out = [];
+  for (const m of ((evidence && evidence.era_matches) || [])) {
+    if (m.kind !== 'keyword' || m.sourceField !== sourceField) continue;
+    const key = m.era + '|' + m.excerpt.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(m);
+  }
+  return out;
+}
+
+function renderPendingCard(c) {
+  const id = c.source_id;
+  const cls = c.classified || {};
+  const conf = cls.confidence || 'low';
+  const quality = c.quality || 'red';
+  const era = cls.era || 'unknown';
+  const isSelected = pendingSelected.has(id);
+  const evidence = c.evidence || {};
+
+  // Pull from any edits the user has typed locally so their work survives a
+  // re-render (e.g., after another card is rejected and the list refreshes).
+  const edits = pendingEdits.get(id) || {};
+  const title    = edits.title    !== undefined ? edits.title    : (c.title || '');
+  const takenAt  = edits.taken_at !== undefined ? edits.taken_at : (c.taken_at || '');
+  const photog   = edits.photographer !== undefined ? edits.photographer : (c.photographer || '');
+  const location = edits.location !== undefined ? edits.location : (c.location || '');
+  const center   = edits.center   !== undefined ? edits.center   : (c.center || '');
+  const eraVal   = edits.era      !== undefined ? edits.era      : era;
+
+  const eraOptions = ['pre-flight-hardware','pre-flight-training','mission','post-mission','unknown']
+      .map(e => `<option value="${e}"${e === eraVal ? ' selected' : ''}>${e}</option>`)
+      .join('');
+
+  return `<div class="pending-card quality-${esc(quality)}" data-id="${esc(id)}">
+    <div class="pending-select">
+      <input type="checkbox" ${isSelected ? 'checked' : ''}
+             onchange="togglePendingSelect(this, '${esc(id)}')">
+    </div>
+    <img class="pending-thumb"
+         src="${esc(c.thumb_url || c.image_url || '')}"
+         alt=""
+         onclick="window.open('${esc(c.source_url || c.image_url || '#')}','_blank')"
+         onerror="this.style.background='#3a1a1a'; this.alt='thumbnail failed';">
+    <div class="pending-body">
+      <div class="pending-title-row">
+        <input value="${esc(title)}" placeholder="Title"
+               onchange="editPending('${esc(id)}','title',this.value)">
+        <div class="pending-badges">
+          <span class="pending-badge conf-${esc(conf)}" title="${esc(buildConfidenceTooltip(cls, evidence))}">${esc(conf)} conf</span>
+          <span class="pending-badge qual-${esc(quality)}" title="${esc(buildQualityTooltip(evidence))}">${esc(quality)}</span>
+          ${c.source ? `<span class="pending-badge source">${esc(c.source)}</span>` : ''}
+          ${center ? `<span class="pending-badge center" title="${esc((evidence.center_source && evidence.center_source.note) || '')}">${esc(center)}</span>` : ''}
+        </div>
+      </div>
+      ${renderTitleMatches(evidence)}
+      ${renderQualityFailures(evidence)}
+      <div class="pending-meta-row">
+        <div class="pending-field">
+          <label>Time</label>
+          <input type="datetime-local" class="time-input" step="1"
+                 value="${esc(takenAt.replace(' ', 'T'))}"
+                 onchange="editPending('${esc(id)}','taken_at',this.value.replace('T',' '))">
+        </div>
+        <div class="pending-field">
+          <label>Era</label>
+          <select onchange="editPending('${esc(id)}','era',this.value)">${eraOptions}</select>
+        </div>
+        <div class="pending-field">
+          <label>Photographer</label>
+          <input class="short" value="${esc(photog)}"
+                 onchange="editPending('${esc(id)}','photographer',this.value)">
+        </div>
+        <div class="pending-field">
+          <label>Location</label>
+          <input class="med" value="${esc(location)}"
+                 onchange="editPending('${esc(id)}','location',this.value)">
+        </div>
+        <div class="pending-field">
+          <label>Center</label>
+          <input class="short" style="width:80px;text-transform:uppercase" value="${esc(center)}"
+                 onchange="editPending('${esc(id)}','center',this.value.toUpperCase())">
+        </div>
+      </div>
+      ${c.description ? `<div class="pending-desc" onclick="this.classList.toggle('expanded')">${highlightField(c.description, evidence, 'description')}</div>` : ''}
+      <div class="pending-actions">
+        <button class="promote" onclick="promoteOne('${esc(id)}')">Promote</button>
+        <button class="reject"  onclick="rejectOne('${esc(id)}')">Reject</button>
+        <button class="view"    onclick="window.open('${esc(c.source_url || c.image_url || '#')}','_blank')">View source ↗</button>
+      </div>
+    </div>
+  </div>`;
+}
+
+// Render "Matched in title:" as small colored chips. Title is editable so
+// we can't use inline <mark>, but we can still surface the matches here.
+function renderTitleMatches(evidence) {
+  const matches = uniqueMatchesForField(evidence, 'title');
+  if (matches.length === 0) return '';
+  const chips = matches
+      .map(m => `<mark class="era-${esc(m.era)}" title="${esc('matched pattern: ' + (m.pattern || m.excerpt) + '  ·  era: ' + m.era)}">${esc(m.excerpt)}</mark>`)
+      .join(' ');
+  return `<div class="pending-title-matches"><strong>Matched in title:</strong> ${chips}</div>`;
+}
+
+// Render quality-score failures below the badges so the reviewer sees
+// why a card is yellow/red without hovering.
+function renderQualityFailures(evidence) {
+  const fails = (evidence && evidence.quality_failures) || [];
+  if (fails.length === 0) return '';
+  const lines = fails.map(f => `${esc(f.field)}: ${esc(f.reason)}`).join(' · ');
+  return `<div class="pending-quality-detail"><strong>Quality:</strong> ${lines}</div>`;
+}
+
+function buildConfidenceTooltip(cls, evidence) {
+  const reason = cls.reason || 'no reason recorded';
+  const matches = ((evidence && evidence.era_matches) || []).filter(m => m.kind === 'keyword');
+  const counts = {};
+  for (const m of matches) counts[m.era] = (counts[m.era] || 0) + 1;
+  const breakdown = Object.entries(counts).map(([e, n]) => `${n}× ${e}`).join(', ');
+  return breakdown ? `${reason}  ·  keywords: ${breakdown}` : reason;
+}
+
+function buildQualityTooltip(evidence) {
+  const fails = (evidence && evidence.quality_failures) || [];
+  if (fails.length === 0) return 'all editorial must-haves present';
+  return fails.map(f => `${f.field}: ${f.reason}`).join('\n');
+}
+
+window.togglePendingSelect = function(checkbox, id) {
+  if (checkbox.checked) pendingSelected.add(id);
+  else pendingSelected.delete(id);
+  updatePendingCount();
+};
+
+window.editPending = function(id, field, value) {
+  const cur = pendingEdits.get(id) || {};
+  cur[field] = value;
+  pendingEdits.set(id, cur);
+};
+
+async function rejectOne(id) {
+  if (!confirm(`Reject candidate "${id}"? It will not reappear on future syncs.`)) return;
+  try {
+    await sidecarFetch('/reject', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source_ids: [id] }),
+    });
+    pendingSelected.delete(id);
+    pendingEdits.delete(id);
+    await loadPending();
+  } catch (err) {
+    alert('Reject failed: ' + err.message);
+  }
+}
+
+async function rejectSelected() {
+  if (pendingSelected.size === 0) { alert('No candidates selected.'); return; }
+  if (!confirm(`Reject ${pendingSelected.size} candidate(s)? They will not reappear.`)) return;
+  const ids = Array.from(pendingSelected);
+  try {
+    await sidecarFetch('/reject', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source_ids: ids }),
+    });
+    for (const id of ids) { pendingSelected.delete(id); pendingEdits.delete(id); }
+    await loadPending();
+  } catch (err) {
+    alert('Reject failed: ' + err.message);
+  }
+}
+
+async function promoteOne(id) {
+  const edits = pendingEdits.get(id) || {};
+  if (!confirm(`Promote candidate "${id}" to photos.js? Image will be downloaded to web/.`)) return;
+  await doPromote([{ source_id: id, edits }]);
+}
+
+async function promoteSelected() {
+  if (pendingSelected.size === 0) { alert('No candidates selected.'); return; }
+  const items = Array.from(pendingSelected).map(id => ({
+    source_id: id,
+    edits: pendingEdits.get(id) || {},
+  }));
+  if (!confirm(`Promote ${items.length} candidate(s) to photos.js? Each image will be downloaded to web/.`)) return;
+  await doPromote(items);
+}
+
+async function doPromote(items) {
+  const btnPromote = document.getElementById('pending-promote-btn');
+  const orig = btnPromote.textContent;
+  btnPromote.disabled = true;
+  btnPromote.textContent = 'Downloading…';
+  try {
+    const result = await sidecarFetch('/promote', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ items, curator: 'johnmknight' }),
+    });
+    // The sidecar mutated photos.js on disk. Reload the page so the in-memory
+    // PHOTO_DATA picks up the new entries — admin.html currently doesn't
+    // hot-reload data and the simplest correctness story is a fresh load.
+    alert(`Promoted ${result.promoted} candidate(s). Reloading admin to refresh PHOTO_DATA.`);
+    window.location.reload();
+  } catch (err) {
+    alert('Promote failed: ' + err.message);
+    btnPromote.disabled = false;
+    btnPromote.textContent = orig;
+  }
+}
+
+async function runSync() {
+  const query   = document.getElementById('pending-query').value.trim();
+  const centers = document.getElementById('pending-centers').value.trim();
+  const limit   = parseInt(document.getElementById('pending-limit').value, 10) || 20;
+  const body = { limit };
+  if (query)   body.query = query;
+  if (centers) body.centers = centers.split(/[,\s]+/).filter(Boolean);
+
+  const btn = document.getElementById('pending-run-btn');
+  const orig = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = 'Running sync…';
+  try {
+    const result = await sidecarFetch('/sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!result.ok) {
+      alert('Sync failed (exit ' + result.exitCode + '):\n\n' + (result.stderr || result.stdout));
+    }
+    await loadPending();
+  } catch (err) {
+    alert('Sync failed: ' + err.message);
+  }
+  btn.disabled = false;
+  btn.textContent = orig;
 }
 </script>
 </body>

--- a/fetch-flickr-descriptions.js
+++ b/fetch-flickr-descriptions.js
@@ -1,17 +1,28 @@
 #!/usr/bin/env node
 /**
- * Fetch missing photo descriptions from Flickr API
+ * Fetch missing photo descriptions from Flickr API.
  *
  * Usage:
  *   node fetch-flickr-descriptions.js
  *
- * This will output a JSON object mapping Flickr photo IDs to their
- * titles and descriptions, ready to paste into photos.js.
+ * Outputs a JSON object mapping Flickr photo IDs to their titles and
+ * descriptions, ready to paste into photos.js (or to feed into the
+ * acquisition pipeline's admin Pending tab).
  *
- * No API key needed — uses the public endpoint.
+ * Requires a Flickr API key. Set it in tools/import/.env.local:
+ *
+ *   FLICKR_API_KEY=your_key_here
+ *
+ * Get a free non-commercial key at
+ * https://www.flickr.com/services/apps/create/apply/
+ *
+ * NOTE: the original version of this script had the API key hardcoded
+ * in this committed file. That key was revoked by Flickr after appearing
+ * in a public repo. Don't put keys in tracked files.
  */
 
 const https = require('https');
+const { requireCredential } = require('./tools/import/shared/env');
 
 const FLICKR_IDS = [
   '55186319833',
@@ -44,8 +55,9 @@ const FLICKR_IDS = [
   '55201423841',
 ];
 
-// Flickr public API key (non-commercial, rate-limited)
-const API_KEY = '0407a2e71f8e025e73a050e6c7a1edf6';
+// Flickr API key loaded from tools/import/.env.local (gitignored). The
+// previous in-file key was revoked after this repo went public.
+const API_KEY = requireCredential('FLICKR_API_KEY');
 
 function fetchPhotoInfo(photoId) {
   return new Promise((resolve, reject) => {

--- a/photos.js
+++ b/photos.js
@@ -11,7 +11,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "SLS Glows at Sunset on Pad 39B",
       "flickr_desc": "NASA's Space Launch System rocket with the Orion spacecraft atop stands on Launch Pad 39B at Kennedy Space Center, bathed in golden sunset light five days before launch.",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "NHQ202603270002",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-03-27 19:15:00",
@@ -24,7 +30,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "SLS and Orion on the Pad With Palm Trees",
       "flickr_desc": "A wide view of NASA's Space Launch System rocket on Launch Pad 39B at Kennedy Space Center, framed by Florida palm trees in the foreground at dusk.",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "NHQ202603270008",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:04:32",
@@ -37,7 +49,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Jeremy Hansen Suited Up and Ready",
       "flickr_desc": "Canadian Space Agency astronaut Jeremy Hansen gives a thumbs-up in the suit-up room at Kennedy Space Center, wearing his orange Orion crew survival suit on launch day.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260401-PH-KLS01_0013",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:08:40",
@@ -50,7 +68,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Helmet Check in the Suit-Up Room",
       "flickr_desc": "A technician assists an Artemis II crew member with a helmet fitting in the suit-up room at Kennedy Space Center. The astronaut sits in the crew chair wearing the orange Orion suit with visor raised.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260401-PH-KLS01_0040",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:09:24",
@@ -63,7 +87,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Victor Glover Gets Final Suit Adjustments",
       "flickr_desc": "NASA astronaut Victor Glover receives final suit adjustments from a technician in the suit-up room at Kennedy Space Center, his helmet on and visor raised.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260401-PH-KLS01_0045",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:13:54",
@@ -76,7 +106,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Victor Glover Waves From the Suit-Up Room",
       "flickr_desc": "NASA astronaut Victor Glover waves from the crew chair in the suit-up room at Kennedy Space Center, fully suited in his orange Orion crew survival suit with helmet on.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260401-PH-KLS01_0061",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:21:01",
@@ -89,7 +125,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Christina Koch Adjusts Her Communications Cap",
       "flickr_desc": "A close-up of NASA astronaut Christina Koch adjusting her communications cap before donning her helmet in the suit-up room at Kennedy Space Center on launch day.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260401-PH-KLS01_0101",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:21:14",
@@ -102,7 +144,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Victor Glover Adjusts His Communications Cap",
       "flickr_desc": "A close-up of NASA astronaut Victor Glover adjusting his communications cap in the suit-up room at Kennedy Space Center on launch day.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260401-PH-KLS01_0106",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:35:39",
@@ -115,7 +163,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Artemis II Crew Portrait in the Suit-Up Room",
       "flickr_desc": "The Artemis II crew poses in the suit-up room at Kennedy Space Center: Christina Koch, Reid Wiseman, Victor Glover, and Jeremy Hansen, all wearing their orange Orion crew survival suits.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260401-PH-KLS01_0198",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:36:09",
@@ -128,7 +182,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Christina Koch Smiles Before Launch",
       "flickr_desc": "NASA astronaut Christina Koch smiles in the suit-up room at Kennedy Space Center, wearing her orange Orion crew survival suit on launch day.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260401-PH-KLS01_0207",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:47:25",
@@ -141,7 +201,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Crew Rides the Elevator to the Transfer Van",
       "flickr_desc": "The Artemis II crew rides the elevator in the Neil Armstrong Operations and Checkout Building at Kennedy Space Center, standing beneath a crew poster and surrounded by the signatures of previous astronaut crews.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260401-PH-KLS01_0270",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:49:20",
@@ -154,7 +220,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Crew Walkout From the O&C Building",
       "flickr_desc": "The Artemis II crew walks out of the Neil Armstrong Operations and Checkout Building at Kennedy Space Center, heading toward the crew transport vehicle on launch day.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "NHQ20260401_admin_0002",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:49:20",
@@ -167,7 +239,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Crew Walkout Wide View",
       "flickr_desc": "The Artemis II crew walks down the ramp from the Neil Armstrong Operations and Checkout Building at Kennedy Space Center, with the crew names banner visible above the doorway.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260401-PH-KLS02_0093",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:51:24",
@@ -182,7 +260,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Walkout (NHQ202604010003)",
       "flickr_desc": "NASA astronauts Reid Wiseman, commander, front right; Victor Glover, pilot, front left; Christina Koch, mission specialist, back right; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist are seen as they depart the Neil A. Armstrong Operations and Checkout Building to board their Orion spacecraft atop NASA’s Space Launch System (SLS) rocket at Launch Complex 39B, Wednesday, April 1, 2026, at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft from Launch Complex 39B, with a two hour launch window opening at 6:24pm. Photo Credit: (NASA/Aubrey Gemignani)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182417729",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:51:57",
@@ -197,7 +281,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Walkout (NHQ202604010009)",
       "flickr_desc": "From right to left, NASA astronauts Christina Koch, mission specialist; Reid Wiseman, commander; Victor Glover, pilot; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist are seen as they depart the Neil A. Armstrong Operations and Checkout Building to board their Orion spacecraft atop NASA’s Space Launch System (SLS) rocket at Launch Complex 39B, Wednesday, April 1, 2026, at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft from Launch Complex 39B, with a two hour launch window opening at 6:24pm. Photo Credit: (NASA/Aubrey Gemignani)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182419584",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:53:11",
@@ -212,7 +302,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Walkout (NHQ202604010011)",
       "flickr_desc": "From right to left, NASA astronauts Reid Wiseman, commander (not pictured); Christina Koch, mission specialist; Victor Glover, pilot; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist are seen as they depart the Neil A. Armstrong Operations and Checkout Building to board their Orion spacecraft atop NASA’s Space Launch System (SLS) rocket at Launch Complex 39B, Wednesday, April 1, 2026, at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft from Launch Complex 39B, with a two hour launch window opening at 6:24pm. Photo Credit: (NASA/Aubrey Gemignani)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182420389",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:54:05",
@@ -227,7 +323,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Walkout (NHQ202604010014)",
       "flickr_desc": "From right to left, NASA astronauts Reid Wiseman, commander; Christina Koch, mission specialist; Victor Glover, pilot; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist (not pictured) are seen as they depart the Neil A. Armstrong Operations and Checkout Building to board their Orion spacecraft atop NASA’s Space Launch System (SLS) rocket at Launch Complex 39B, Wednesday, April 1, 2026, at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft from Launch Complex 39B, with a two hour launch window opening at 6:24pm. Photo Credit: (NASA/Aubrey Gemignani)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182564820",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:54:50",
@@ -242,7 +344,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Walkout (NHQ202604010019)",
       "flickr_desc": "From right to left, NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist gesture to family and friends as they depart the Neil A. Armstrong Operations and Checkout Building to board their Orion spacecraft atop NASA’s Space Launch System (SLS) rocket at Launch Complex 39B, Wednesday, April 1, 2026, at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft from Launch Complex 39B, with a two hour launch window opening at 6:24pm. Photo Credit: (NASA/Aubrey Gemignani)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182566490",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 13:55:08",
@@ -257,7 +365,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Walkout (NHQ202604010021)",
       "flickr_desc": "From right to left, NASA astronauts Reid Wiseman, commander; Christina Koch, mission specialist; Victor Glover, pilot; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist wave to family and friends as they prepare to depart the Neil A. Armstrong Operations and Checkout Building to board their Orion spacecraft atop NASA’s Space Launch System (SLS) rocket at Launch Complex 39B, Wednesday, April 1, 2026, at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft from Launch Complex 39B, with a two hour launch window opening at 6:24pm. Photo Credit: (NASA/Aubrey Gemignani)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182566975",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 14:06:10",
@@ -272,7 +386,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Preflight (NHQ202604010202)",
       "flickr_desc": "The astrovan with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist, drives by the Vehicle Assembly Building towards Launch Complex 39B ahead of the crew boarding their Orion spacecraft atop NASA’s Space Launch System (SLS) rocket, Wednesday, April 1, 2026, at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard SLS rocket and Orion spacecraft from Launch Complex 39B, with a two hour launch window opening at 6:24 p.m. EDT. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182399029",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 14:20:56",
@@ -287,7 +407,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Preflight (NHQ202604010205)",
       "flickr_desc": "NASA’s Space Launch System (SLS) rocket with the Orion spacecraft aboard is seen atop the mobile launcher after the arrival of NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist at Launch Complex 39B, Wednesday, April 1, 2026, as the launch countdown progresses at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard SLS rocket and Orion spacecraft from Launch Complex 39B, with a two hour launch window opening at 6:24 p.m. EDT. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182336933",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 15:05:27",
@@ -302,7 +428,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Preparing for Liftoff",
       "flickr_desc": "jsc2026e019363 (April 1, 2026) – Public Affairs Officer Gary Jordan prepares for the Artemis II launch in the White Flight Control Room in the Mission Control Center at NASA’s Johnson Space Center. NASA’s Artemis II SLS (Space Launch System) rocket, with the Orion spacecraft atop carrying NASA astronauts Reid Wiseman, Victor Glover, and Christina Koch, along with CSA (Canadian Space Agency) astronaut Jeremy Hansen, lifted off from Kennedy Space Center’s Launch Complex 39B in Florida at 6:35 p.m. ET to begin its journey to deep space. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55196404298",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-01 15:08:51",
@@ -315,7 +447,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Crew Walks to the Launch Pad",
       "flickr_desc": "Victor Glover and Jeremy Hansen lead the Artemis II crew out of the Operations and Checkout building, walking toward the crew transport vehicle at Kennedy Space Center.",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260401-PH-KLS02_0009",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 15:34:08",
@@ -330,7 +468,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Preflight (NHQ202604010117)",
       "flickr_desc": "Lucas Ye, designer of zero gravity indicator “Rise,” participates in an interview with members of the NASA Broadcast team at the Banana Creek viewing site as the countdown progresses for the launch of NASA’s Space Launch System (SLS) rocket and Orion spacecraft with Commander Reid Wiseman, Pilot Victor Glover, and Mission Specialist Christina Koch from NASA, and Mission Specialist Jeremy Hansen from the CSA (Canadian Space Agency) on the Artemis II mission, Wednesday, April 1, 2026, at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard SLS rocket and Orion spacecraft from Launch Complex 39B with launch window opening at 6:24 p.m. EDT. Photo Credit: (NASA/Keegan Barber)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55186418959",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 15:45:12",
@@ -345,7 +489,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch",
       "flickr_desc": "Launch of NASA’s Space Launch System rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on NASA’s Artemis II mission, Wednesday, April 1, 2026, from Operations and Support Building II at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard SLS rocket and Orion spacecraft launched at from Launch Complex 39B. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182525528",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2025-01-30 12:00:00",
@@ -360,7 +510,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "NASA astronaut and Artemis II Pilot Victor Glover inside of the Orion spacecraft mockup during Post Insertion and Deorbit Preparation Training",
       "flickr_desc": "jsc2025e004071 (Jan. 30, 2025) --- NASA astronaut and Artemis II Pilot Victor Glover inside of the Orion spacecraft mockup during Post Insertion and Deorbit Preparation training at the Space Vehicle Mockup Facility in Houston, Texas. The crew practiced getting the Orion spacecraft configured once in orbit, how to make it habitable, and suited up in their entry pressure suits to prepare for their return from the Moon. Credit: NASA/Mark Sowa",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "54424847440",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-01 16:13:42",
@@ -375,7 +531,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010025)",
       "flickr_desc": "Teams monitor the countdown of the launch of NASA’s Space Launch System (SLS) rocket and Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard on the Artemis II mission from Firing Room 2 of the Rocco A. Petrone Launch Control Center, Wednesday, April 1, 2026, at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard SLS rocket and Orion spacecraft from Launch Complex 39B. The quartet launched at 6:35pm EDT. Photo Credit: (NASA/Aubrey Gemignani)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55183849497",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 16:19:32",
@@ -390,7 +552,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010025)",
       "flickr_desc": "NASA Chief Health and Medical Officer Dr. J.D. Polk monitors the countdown of the launch of NASA’s Space Launch System (SLS) rocket and Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard on the Artemis II mission from Firing Room 2 of the Rocco A. Petrone Launch Control Center, Wednesday, April 1, 2026, at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard SLS rocket and Orion spacecraft from Launch Complex 39B. The quartet launched at 6:35pm EDT. Photo Credit: (NASA/Aubrey Gemignani)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55184740196",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 17:05:12",
@@ -405,7 +573,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010025)",
       "flickr_desc": "Director of NASA's Kennedy Space Center, Janet Petro, left, and Director of NASA's Johnson Space Center, Vanessa Wyche, monitor the countdown of the launch of NASA’s Space Launch System (SLS) rocket and Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard on the Artemis II mission from Firing Room 2 of the Rocco A. Petrone Launch Control Center, Wednesday, April 1, 2026, at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard SLS rocket and Orion spacecraft from Launch Complex 39B. The quartet launched at 6:35pm EDT. Photo Credit: (NASA/Aubrey Gemignani)",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55183854612",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:03",
@@ -420,7 +594,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010213)",
       "flickr_desc": "NASA’s Space Launch System rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard launches on the Artemis II mission, Wednesday, April 1, 2026, from Launch Complex 39B at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft. The quartet launched at 6:35 p.m. EDT, from Launch Complex 39B at the Kennedy Space Center. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182788563",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:34:30",
@@ -435,7 +615,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010257)",
       "flickr_desc": "NASA’s Space Launch System rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard launches on the Artemis II mission, Wednesday, April 1, 2026, from Launch Complex 39B at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft. The quartet launched at 6:35 p.m. EDT, from Launch Complex 39B at the Kennedy Space Center. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55184539204",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:34:30",
@@ -450,7 +636,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010263)",
       "flickr_desc": "NASA’s Space Launch System rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard launches on the Artemis II mission, Wednesday, April 1, 2026, from Launch Complex 39B at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft. The quartet launched at 6:35 p.m. EDT, from Launch Complex 39B at the Kennedy Space Center. Photo Credit: (NASA/Aubrey Gemignani)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55184537894",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:34:30",
@@ -465,7 +657,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Launch",
       "flickr_desc": "NASA’s Space Launch System rocket launches carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on NASA’s Artemis II mission, Wednesday, April 1, 2026, from Operations and Support Building II at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard SLS rocket and Orion spacecraft launched at 6:35pm EDT from Launch Complex 39B. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182696113",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:34:40",
@@ -480,7 +678,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010224)",
       "flickr_desc": "NASA’s Space Launch System rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard launches on the Artemis II mission, Wednesday, April 1, 2026, from Launch Complex 39B at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft. The quartet launched at 6:35 p.m. EDT, from Launch Complex 39B at the Kennedy Space Center. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182918876",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:34:40",
@@ -495,7 +699,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "SLS Twin Boosters Ignite",
       "flickr_desc": "The twin solid rocket boosters of NASA's Space Launch System roar to life, producing massive plumes of flame and smoke as Artemis II lifts off from Kennedy Space Center on April 1, 2026. The close-up shot captures the raw power of the four RS-25 engines and two boosters generating 8.8 million pounds of thrust.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55186319833",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:34:40",
@@ -510,7 +720,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Launch",
       "flickr_desc": "NASA’s Space Launch System rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard launches on the Artemis II mission, Wednesday, April 1, 2026, from Launch Complex 39B at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft. The quartet launched at 6:35 p.m. EDT, from Launch Complex 39B at the Kennedy Space Center. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182789108",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:34:40",
@@ -525,7 +741,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Launch",
       "flickr_desc": "NASA’s Space Launch System rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard launches on the Artemis II mission, Wednesday, April 1, 2026, from Launch Complex 39B at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft. The quartet launched at 6:35 p.m. EDT, from Launch Complex 39B at the Kennedy Space Center. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55183079963",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:34:41",
@@ -540,7 +762,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010224)",
       "flickr_desc": "NASA’s Space Launch System rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard launches on the Artemis II mission, Wednesday, April 1, 2026, from Launch Complex 39B at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft. The quartet launched at 6:35 p.m. EDT, from Launch Complex 39B at the Kennedy Space Center. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182911249",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:34:41",
@@ -555,7 +783,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010226)",
       "flickr_desc": "NASA’s Space Launch System rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard launches on the Artemis II mission, Wednesday, April 1, 2026, from Launch Complex 39B at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft. The quartet launched at 6:35 p.m. EDT, from Launch Complex 39B at the Kennedy Space Center. Photo Credit: (NASA/Aubrey Gemignani)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55181836272",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:34:41",
@@ -570,7 +804,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Launch",
       "flickr_desc": "NASA’s Space Launch System rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard launches on the Artemis II mission, Wednesday, April 1, 2026, from Launch Complex 39B at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft. The quartet launched at 6:35 p.m. EDT, from Launch Complex 39B at the Kennedy Space Center. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55183089523",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:35:17",
@@ -585,7 +825,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010107)",
       "flickr_desc": "Guests at the Banana Creek viewing site watch the launch of NASA’s Space Launch System (SLS) rocket and Orion spacecraft with Commander Reid Wiseman, Pilot Victor Glover, and Mission Specialist Christina Koch from NASA, and Mission Specialist Jeremy Hansen from the CSA (Canadian Space Agency) on the Artemis II mission, Wednesday, April 1, 2026, at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard SLS rocket and Orion spacecraft. The quartet launched at 6:35 p.m. EDT from Launch Complex 39B. Photo Credit: (NASA/Keegan Barber)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55181691437",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:35:37",
@@ -600,7 +846,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010225)",
       "flickr_desc": "Crawler Transporter 2 is seen as NASA’s Space Launch System rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard launches on the Artemis II mission, Wednesday, April 1, 2026, from Launch Complex 39B at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft. The quartet launched at 6:35 p.m. EDT, from Launch Complex 39B at the Kennedy Space Center. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55183122230",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:35:57",
@@ -615,7 +867,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010309)",
       "flickr_desc": "Employees and invited guest, including Eric Trump family, left, and Donald Trump Jr. family, right, watch the launch of NASA’s Space Launch System rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on NASA’s Artemis II mission,, Wednesday, April 1, 2026, from Operations and Support Building II at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard SLS rocket and Orion spacecraft launched at 6:35pm EDT from Launch Complex 39B. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55181712417",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:36:32",
@@ -630,7 +888,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010310)",
       "flickr_desc": "Guests watch the launch of NASA’s Space Launch System rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on NASA’s Artemis II mission,, Wednesday, April 1, 2026, from Operations and Support Building II at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard SLS rocket and Orion spacecraft launched at 6:35pm EDT, from Launch Complex 39B. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182858034",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:36:51",
@@ -645,7 +909,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010216)",
       "flickr_desc": "NASA’s Space Launch System rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard launches on the Artemis II mission, Wednesday, April 1, 2026, from Launch Complex 39B at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft. The quartet launched at 6:35 p.m. EDT, from Launch Complex 39B at the Kennedy Space Center. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55181733197",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:37:05",
@@ -660,7 +930,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Launch",
       "flickr_desc": "NASA’s Space Launch System rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard launches on the Artemis II mission, Wednesday, April 1, 2026, from Launch Complex 39B at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft. The quartet launched at 6:35 p.m. EDT, from Launch Complex 39B at the Kennedy Space Center. Photo Credit: (NASA/Keegan Barber)",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182980490",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:37:10",
@@ -675,7 +951,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Launch",
       "flickr_desc": "NASA’s Space Launch System rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard launches on the Artemis II mission, Wednesday, April 1, 2026, from Launch Complex 39B at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft. The quartet launched at 6:35 p.m. EDT, from Launch Complex 39B at the Kennedy Space Center. Photo Credit: (NASA/Keegan Barber)",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55182992165",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:37:30",
@@ -690,7 +972,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Launch",
       "flickr_desc": "The solid rocket boosters are seen as they fall away after separating from NASA’s Space Launch System (SLS) rocket carrying the Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard as it continues toward orbit on the Artemis II mission, Wednesday, April 1, 2026, from Launch Complex 39B at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard their Orion spacecraft. The quartet launched at 6:35 p.m. EDT, from Launch Complex 39B at the Kennedy Space Center. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55181746722",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:37:30",
@@ -703,7 +991,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Solid Rocket Boosters Separate",
       "flickr_desc": "An infrared camera captures the two solid rocket boosters separating from the SLS core stage approximately two minutes after liftoff, with the Orion spacecraft visible below.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260401-PH-SFL01_0002",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-01 18:44:11",
@@ -718,7 +1012,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010050)",
       "flickr_desc": "Teams celebrate after the launch of NASA’s Space Launch System (SLS) rocket and Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard the Artemis II mission in Firing Room 2 of the Rocco A. Petrone Launch Control Center, Wednesday, April 1, 2026, at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard SLS rocket and Orion spacecraft from Launch Complex 39B. The quartet launched at 6:35pm EDT. Photo Credit: (NASA/Aubrey Gemignani)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55184745301",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:44:19",
@@ -733,7 +1033,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010051)",
       "flickr_desc": "Teams celebrate after the launch of NASA’s Space Launch System (SLS) rocket and Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard the Artemis II mission in Firing Room 2 of the Rocco A. Petrone Launch Control Center, Wednesday, April 1, 2026, at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard SLS rocket and Orion spacecraft from Launch Complex 39B. The quartet launched at 6:35pm EDT. Photo Credit: (NASA/Aubrey Gemignani)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55185003259",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 18:49:10",
@@ -748,7 +1054,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010054)",
       "flickr_desc": "Teams review images of launch complex 39B after the launch of NASA’s Space Launch System (SLS) rocket and Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard on the Artemis II mission in Firing Room 2 of the Rocco A. Petrone Launch Control Center, Wednesday, April 1, 2026, at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard the SLS rocket and Orion spacecraft. The quartet launched at 6:35pm EDT . Photo Credit: (NASA/Aubrey Gemignani) NOTE - Portions of this image have been blurred for security reasons.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55185144555",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 19:37:21",
@@ -763,7 +1075,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Launch (NHQ202604010059)",
       "flickr_desc": "Artemis II mission teams pose for a selfie with NASA Administrator Jared Isaacman after monitor the launch of NASA’s Space Launch System (SLS) rocket and Orion spacecraft with NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard on the Artemis II mission in Firing Room 2 of the Rocco A. Petrone Launch Control Center, Wednesday, April 1, 2026, at NASA’s Kennedy Space Center in Florida. NASA’s Artemis II mission will take Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back aboard SLS rocket and Orion spacecraft from Launch Complex 39B. The quartet launched at 6:35pm EDT. Photo Credit: (NASA/Aubrey Gemignani) NOTE - Portions of this image have been blurred for security reasons.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55186154951",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "KSC"
     },
     {
       "time": "2026-04-01 21:27:22",
@@ -778,7 +1096,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Proximity Operations Demonstration from Mission Control",
       "flickr_desc": "jsc2026e019217 (April 1, 2026) – Lead Artemis II Flight Director Jeff Radigan in the White Flight Control Room at the Mission Control Center at NASA’s Johnson Space Center in Houston. At the time of this photograph, a little over three hours into the mission, the Artemis II crew was conducting a manual piloting test called the proximity operations demonstration. During the demonstration, mission controllers monitored Orion as the astronauts transitioned the spacecraft to manual mode and piloted its flight path and orientation. This demonstration will provide performance data and operational experience that cannot be readily gained on the ground in preparation for critical rendezvous, proximity operations, docking, and undocking for future Artemis missions. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55196507489",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-01 21:37:00",
@@ -793,7 +1117,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Email Trouble",
       "flickr_desc": "The Artemis II crew discovers they have two Microsoft Outlooks open and neither microphone is working — a familiar IT moment, 3,300 miles from Earth. — via YouTube Shorts",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "yt-mic-trouble",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-01 21:45:05",
@@ -808,7 +1138,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Lead Flight Director Jeff Radigan During Prox Ops Demo",
       "flickr_desc": "jsc2026e019242 (April 1, 2026) – Lead Artemis II Flight Director Jeff Radigan in the White Flight Control Room at the Mission Control Center at NASA’s Johnson Space Center in Houston. At the time of this photograph, a little over three hours into the mission, the Artemis II crew began a manual piloting test called the proximity operations demonstration. During the demonstration, mission controllers monitored Orion as the astronauts transitioned the spacecraft to manual mode and piloted its flight path and orientation. This demonstration will provide performance data and operational experience that cannot be readily gained on the ground in preparation for critical rendezvous, proximity operations, docking, and undocking for future Artemis missions. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55196663265",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-01 22:21:15",
@@ -823,7 +1159,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Manual Piloting NASA's Orion Spacecraft",
       "flickr_desc": "jsc2026e019255 (April 1, 2026) – Lead Artemis II Flight Director Jeff Radigan (left) and capsule communicator (capcom) Amy Dill (right) in the White Flight Control Room at the Mission Control Center at NASA’s Johnson Space Center in Houston. At the time of this photograph, a little over three hours into the mission, the Artemis II crew conducting a manual piloting test called the proximity operations demonstration. During the demonstration, mission controllers monitored Orion as the astronauts transitioned the spacecraft to manual mode and piloted its flight path and orientation. This demonstration will provide performance data and operational experience that cannot be readily gained on the ground in preparation for critical rendezvous, proximity operations, docking, and undocking for future Artemis missions. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55196252006",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-02 08:15:52",
@@ -839,7 +1181,13 @@ const PHOTO_DATA = {
       "title": "A Crescent View of Home",
       "flickr_desc": "A crescent Earth photographed from the Orion spacecraft during the early hours of the Artemis II mission. The planet's sunlit edge reveals swirling cloud patterns and blue ocean, while the rest falls into shadow against the blackness of space.",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55224434205",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 08:26:45",
@@ -855,7 +1203,13 @@ const PHOTO_DATA = {
       "title": "Earth Up Close from Orbit",
       "flickr_desc": "A close-up view of Earth's curved horizon from low orbit, showing detailed cloud formations, ocean, and landmass. Taken with a 400mm telephoto lens during the crew's initial orbits before the translunar injection burn.",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55223125677",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 14:45:18",
@@ -871,7 +1225,13 @@ const PHOTO_DATA = {
       "title": "Watching Earth Shrink",
       "flickr_desc": "Earth appears as a half-lit sphere receding into the distance as Orion coasts toward the Moon. Sunlight illuminates swirling storm systems and the planet's thin blue atmosphere against the void of space.",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55224434210",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 14:53:12",
@@ -887,7 +1247,13 @@ const PHOTO_DATA = {
       "title": "Artemis II Looking Back at Earth",
       "flickr_desc": "art002e000191 (April 3, 2026) - A view of Earth taken by NASA astronaut and Artemis II commander Reid Wiseman from one of the Orion spacecraft's four main windows after completing the translunar injection burn on April 2, 2026. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55184586022",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 16:55:15",
@@ -903,7 +1269,13 @@ const PHOTO_DATA = {
       "title": "Artemis II Captures the Terminator Line",
       "flickr_desc": "art002e000190 (April 3, 2026) - A view of Earth taken by NASA astronaut and Artemis II Commander Reid Wiseman from one of the Orion spacecraft's four windows after completing the translunar injection burn on April 2, 2026. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55184731952",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 17:05:29",
@@ -919,7 +1291,13 @@ const PHOTO_DATA = {
       "title": "Earth from the Outbound Coast",
       "flickr_desc": "A telephoto view of Earth's curved horizon during the outbound coast to the Moon, showing cloud bands and the thin blue line of the atmosphere. The spacecraft is now tens of thousands of miles from home.",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55224434240",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 18:24:11",
@@ -934,7 +1312,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Capsule Communicator",
       "flickr_desc": "jsc2026e020046 (April 2, 2026) – CSA (Canadian Space Agency) astronaut and backup Artemis II crew member Jenni Gibbons serves as capsule communicator (capcom) during the mission’s translunar injection burn, which sent the crew in Orion out of Earth orbit and on a trajectory toward the Moon. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55196698385",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-02 18:27:51",
@@ -949,7 +1333,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Communicating with the Crew from Console",
       "flickr_desc": "jsc2026e019614 (April 2, 2026) – NASA astronaut Chris Birch serves as capsule communicator (capcom) in the Mission Control Center at NASA’s Johnson Space Center during the mission’s translunar injection burn, which sent the crew in Orion out of Earth orbit and on a trajectory toward the Moon. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55196534939",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-02 18:28:00",
@@ -964,7 +1354,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Setting the Course",
       "flickr_desc": "jsc2026e020048 (April 2, 2026) – Flight Dynamics Officer Natasha Peake in Mission Control during Artemis II’s translunar injection burn on April 2, 2026, which not only sent the crew in Orion out of Earth orbit and on a trajectory toward the Moon, but also set them on the course that will ultimately bring them home for a splashdown in the Pacific Ocean. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55195674427",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-02 18:41:23",
@@ -979,7 +1375,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Thinking of You, Earth",
       "flickr_desc": "NASA astronaut and Artemis II Commander Reid Wiseman peers out of one of the Orion spacecraft's main cabin windows, looking back at Earth, as the crew travels towards the Moon. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55187684915",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 18:42:35",
@@ -994,7 +1396,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Home, Seen from Orion.",
       "flickr_desc": "art002e009007 (April 4, 2026) - NASA astronaut and Artemis II Commander Reid Wiseman peers out of one of the Orion spacecraft's main cabin windows, looking back at Earth, as the crew travels towards the Moon. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55187189317",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 18:44:38",
@@ -1009,7 +1417,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Spaceship Earth",
       "flickr_desc": "NASA astronaut and Artemis II mission specialist Christina Koch peers out of one of the Orion spacecraft's main cabin windows, looking back at Earth, as the crew travels towards the Moon. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55187293546",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 18:45:00",
@@ -1024,7 +1438,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Earthshine",
       "flickr_desc": "Earthshine. Artemis II astronaut Christina Koch captured this video of Earth outside the Orion spacecraft windows during the lunar flyby. — Christina Koch via Instagram",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ig-earthshine-koch",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 19:44:40",
@@ -1040,7 +1460,13 @@ const PHOTO_DATA = {
       "title": "Earth Through Orion's Window",
       "flickr_desc": "Earth's cloud-covered surface seen through one of Orion's crew cabin windows, with the window frame visible around the edges. The wide-angle lens captures the full window view as the crew looks back at their home planet during the outbound transit.",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55224193193",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 19:45:21",
@@ -1055,7 +1481,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "The Artemis II Flight Control Team Monitoring the TLI Burn",
       "flickr_desc": "jsc2026e019618 (April 2, 2026) – The Artemis II flight control team pictured at the White Flight Control Room in the Mission Control Center at NASA’s Johnson Space Center monitors mission operations during the translunar injection (TLI) burn, which sent the crew in Orion out of Earth orbit and on a trajectory toward the Moon. After the mission management team polled “Go” for the operation, NASA’s Orion spacecraft fired its main engine for five minutes and 50 seconds beginning at 7:49 p.m. ET, to successfully complete the TLI burn. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55196543334",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-02 20:00:03",
@@ -1070,7 +1502,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Monitoring the Mission",
       "flickr_desc": "Artemis II Flight Control Team in White Flight Control Room (WFCR) during Trans Lunar Insertion Burn. Location: Bldg. 30 MCC WFCR. Date: 4/2/2026. Photo credit: NASA/Helen Arase Vargas",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55195410937",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-02 20:27:20",
@@ -1086,7 +1524,13 @@ const PHOTO_DATA = {
       "title": "Artemis II Captures Dark Side of the Earth",
       "flickr_desc": "art002e000193 (April 3, 2026) - A view of a backlit Earth taken by NASA astronaut and Artemis II Commander Reid Wiseman from one of the Orion spacecraft's window after completing the translunar injection burn on April 2, 2026. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55185622941",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 20:27:39",
@@ -1102,7 +1546,13 @@ const PHOTO_DATA = {
       "title": "Hello, World",
       "flickr_desc": "art002e000192 (April 3, 2026) - A view of Earth taken by NASA astronaut and Artemis II Commander Reid Wiseman from one of the Orion spacecraft's window after completing the translunar injection burn on April 2, 2026. The image features two auroras (top right and bottom left) and zodiacal light (bottom right) is visible as the Earth eclipses the Sun. Venus is shown on the bottom right of the image. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55185633398",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 20:28:00",
@@ -1117,7 +1567,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Earth Rotating From Deep Space",
       "flickr_desc": "A looping time-lapse of Earth slowly rotating as seen from the Orion spacecraft during the outbound translunar coast, compiled from crew photographs by Reddit user u/ResponsibilityNo2097.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "loop",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-03 08:48:33",
@@ -1132,7 +1588,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Orion Snaps a Selfie During External Inspection",
       "flickr_desc": "art002e004411 (April 3, 2026) - Orion snapped this high-resolution selfie in space with a camera mounted on one of its solar array wings during a routine external inspection of the spacecraft on the second day into the Artemis II mission. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55186615484",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-03 10:12:38",
@@ -1147,7 +1609,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Hello, Moon",
       "flickr_desc": "art002e004411 (April 3, 2026) - The Artemis II crew is en route to the Moon on the second flight day of the mission. This photo shows the Orion spacecraft with the Moon in the distance, as captured by a camera on the tip of one of its solar array wings. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55186454418",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-03 10:21:47",
@@ -1162,7 +1630,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Orion and the Moon on Flight Day 2",
       "flickr_desc": "art002e004429 (April 3, 2026) - The Artemis II crew is en route to the Moon on the second flight day of the mission. This photo shows the Orion spacecraft with the Moon in the distance, as captured by a camera on the tip of one of its solar array wings. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55186770575",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-03 19:30:32",
@@ -1177,7 +1651,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "A Crescent Earth",
       "flickr_desc": "art002e00444 (April 3, 2026) - An illuminated sliver of Earth set against the blackness of space is seen through the window of the Orion spacecraft in this photograph from the Artemis II crew on the third day of their journey to the Moon. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55187172560",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-03 19:32:38",
@@ -1193,7 +1673,13 @@ const PHOTO_DATA = {
       "title": "Eyes on Earth",
       "flickr_desc": "art002e009166 (April 3, 2026) - A sliver of Earth is illuminated against the blackness of space in this photo taken by an Artemis II crew member through an Orion spacecraft window on the third day of the mission. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55188864542",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-03 19:38:22",
@@ -1209,7 +1695,13 @@ const PHOTO_DATA = {
       "title": "A Peek at Earth",
       "flickr_desc": "art002e009174 (April 3, 2026) - Peering out the window of the Orion spacecraft at a sliver of the Earth illuminated by the blackness of space. This image was taken by an Artemis II crew member on the third day of the mission. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55189799111",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-03 19:38:59",
@@ -1225,7 +1717,13 @@ const PHOTO_DATA = {
       "title": "Crescent Earth",
       "flickr_desc": "art002e004437 (April 3, 2026) - A sliver of Earth is illuminated against the blackness of space in this photo taken by an Artemis II crew member through an Orion spacecraft window on the third day of the mission. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55187298155",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-03 19:44:47",
@@ -1241,7 +1739,13 @@ const PHOTO_DATA = {
       "title": "To the Moon",
       "flickr_desc": "art002e004438 (April 3, 2026) - A view of the Moon taken by an Artemis II crewmember through the window of the Orion spacecraft on the third day of the mission. The image includes a portion of the Orientale basin (far left), a first for humans and human eyes. Until today, only robotic imagers have seen this region of our Moon. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55186902076",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-03 19:48:56",
@@ -1257,7 +1761,13 @@ const PHOTO_DATA = {
       "title": "CSA Astronaut Jeremy Hansen Takes a Look Through Orion's Window",
       "flickr_desc": "art002e004439 (April 3, 2026) - CSA (Canadian Space Agency) astronaut Jeremy Hansen – in the center of the image – peers out the window of the Orion spacecraft on day 3 of NASA's Artemis II mission. The controls over the commander and pilot seats are illuminated in the foreground, but the cabin is otherwise dark to avoid unnecessary glares on the windows. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55186933788",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-03 19:49:20",
@@ -1273,7 +1783,13 @@ const PHOTO_DATA = {
       "title": "Illuminated in Orion",
       "flickr_desc": "art002e004440 (April 3, 2026) - NASA astronaut Christina Koch is illuminated by a screen inside the darkened Orion spacecraft on the third day of the agency's Artemis II mission. To the right of the image's center, CSA (Canadian Space Agency) astronaut Jeremy Hansen is seen in profile peering out of one of Orion's windows. Lights are turned off to avoid glare on the windows. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55187055368",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-03 22:03:18",
@@ -1289,7 +1805,13 @@ const PHOTO_DATA = {
       "title": "Closing in on the Moon",
       "flickr_desc": "art002e009006 (April 4, 2026) - The Artemis II crew took this photo on day 4 of their journey to the Moon. In it, the Moon is oriented with the South Pole at the top and are beginning to see parts of the lunar far side. Orientale basin is on the right edge of the lunar disk in this image. Artemis II marks the first time that humans have seen the entire basin. The Artemis II crew will continue to observe Orientale from multiple angles as they approach the Moon and throughout the lunar flyby. Orientale is the textbook multi-ring impact basin used as a baseline to compare other impact craters on rocky worlds from Mercury to Pluto. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55187348577",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-04 00:34:19",
@@ -1305,7 +1827,13 @@ const PHOTO_DATA = {
       "title": "A Unique Perspective of Home",
       "flickr_desc": "art002e004450 (April 4, 2026) - Earth is illuminated against the blackness of space in this photo taken by an Artemis II crew member through an Orion spacecraft window. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55190036409",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-04 01:06:49",
@@ -1321,7 +1849,13 @@ const PHOTO_DATA = {
       "title": "Our Home Planet",
       "flickr_desc": "art002e004462 (April 4, 2026) - A sliver of Earth is illuminated against the blackness of space in this photo taken by an Artemis II crew member through an Orion spacecraft window. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55189767696",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-04 03:45:00",
@@ -1336,7 +1870,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Artemis II streaks through the stars",
       "flickr_desc": "Time-lapse of Artemis II spacecraft as seen from the ground, streaking through the star field. Captured by Scott Ferguson, PhD of Astronomy Live.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "4-4-26_07_45UT",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-04 11:35:00",
@@ -1351,7 +1891,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Pink Pony Club Morning",
       "flickr_desc": "What really happened on Pink Pony Club morning. Wake-up songs are a tradition at NASA, and this crew got Chappell Roan’s Pink Pony Club on Flight Day 4. Sound on! — via Instagram",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ig-pink-pony-club",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-04 12:20:54",
@@ -1366,7 +1912,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Rest Before Lunar Flyby",
       "flickr_desc": "art002e009215 (April 6, 2026) - Artemis II crewmember sleeping bags are illuminated inside the Orion spacecraft on Flight Day 5 of the mission and ahead of the crew's lunar flyby on April 6, 2026. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55190303117",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-04 19:23:11",
@@ -1381,7 +1933,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Jeremy Hansen Takes a Selfie in Orion",
       "flickr_desc": "art002e009008 (April 4, 2026) - Artemis II Mission Specialist Jeremy Hansen is seen through a window of the Orion spacecraft while on his way to the Moon. This selfie-style photo was taken using a camera on the end of one of Orion's solar array wings on flight day 4 of the approximately 10-day test flight, when Orion was more than halfway to the Moon. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55195961058",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-04 19:23:14",
@@ -1396,7 +1954,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "A Crew Selfie with Rise in Orion",
       "flickr_desc": "art002e009013 (April 4, 2026) - Artemis II Mission Specialist Christina Koch is seen through a window of the Orion spacecraft while on her way to the Moon. This selfie-style photo was taken using a camera on the end of one of Orion's solar array wings on flight day 4 of the approximately 10-day test flight, when Orion was more than halfway to the Moon. Koch is holding &quot;Rise&quot;, the zero gravity indicator that launched with the crew after being selected from more than 2,600 original designs that were submitted from countries around the world. A zero gravity indicator is a small plush item that typically rides with a crew to visually indicate when they are in space. “Rise” was inspired by the iconic Earthrise moment from the Apollo 8 mission. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194920227",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-04 19:23:41",
@@ -1411,7 +1975,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Christina Koch and Reid Wiseman Take a Selfie in Orion",
       "flickr_desc": "art002e009014 (April 4, 2026) - Artemis II Mission Specialist Christina Koch (center) and Commander Reid Wiseman (top) are seen through windows of the Orion spacecraft while on their way to the Moon. This selfie-style photo was taken using a camera on the end of one of Orion's solar array wings on flight day 4 of the approximately 10-day test flight, when Orion was more than halfway to the Moon. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194920222",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-04 20:30:40",
@@ -1426,7 +1996,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Smiles in Mission Control",
       "flickr_desc": "A flight controller smiles at her console in the White Flight Control Room at NASA's Johnson Space Center during the Artemis II mission. The room buzzes with activity as teams monitor the spacecraft's trajectory toward the Moon.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55206257809",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-04 23:49:45",
@@ -1441,7 +2017,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "All in a Day's Work",
       "flickr_desc": "art002e009206 (April 4, 2026) - NASA astronaut and Artemis II mission specialist Christina Koch, seen here on the fourth day of the mission, prepping for lunar flyby activities after completing aerobic exercise on the flywheel device. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55190613700",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-05 00:02:50",
@@ -1456,7 +2038,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "The Nearside of the Moon",
       "flickr_desc": "art002e009057 (April 4, 2026) - A view of the nearside of the Moon, the side we always see from Earth. Some of the far side is visible, as well, on the left edge, just beyond the black patch that is Orientale basin, a nearly 600-mile-wide crater that straddles the Moon’s near and far sides and is partly visible from Earth. The dark areas in the center and right side of the disk are ancient lava flows, which are unique to the near side of the Moon. The white dot at the bottom of the disk, with white rays shooting out from it, is Tycho crater, one of the younger craters on the Moon at 108 million years old. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55190158269",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-05 02:35:18",
@@ -1472,7 +2060,13 @@ const PHOTO_DATA = {
       "title": "One Day Closer to the Moon",
       "flickr_desc": "art002e009186 (April 5, 2026) - Peering out one of the four windows near the display console on the Orion spacecraft, the Earth is illuminated by the blackness of space and grows smaller as the crew journeys closer to the Moon. This image was taken by an Artemis II crew member on the fourth day of the mission. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55189687036",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-05 02:39:36",
@@ -1488,7 +2082,13 @@ const PHOTO_DATA = {
       "title": "Mother Earth",
       "flickr_desc": "art002e009205 (April 4, 2026) - A thin arc glowing in the darkness of space. Sunlight traces the curves of the ocean and clouds, while the rest of the planet fades into shadow. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55190200376",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-05 13:23:47",
@@ -1504,7 +2104,13 @@ const PHOTO_DATA = {
       "title": "A Quick Shave Before Lunar Flyby",
       "flickr_desc": "art002e009211 (April 6, 2026) - Artemis II mission specialist and CSA (Canadian Space Agency) astronaut Jeremy Hansen enjoys a shave inside the Orion spacecraft during Flight Day 5 and ahead of the crew's lunar flyby on April 6, 2026. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55191185696",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-05 22:10:46",
@@ -1519,7 +2125,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Lunar Science Team – Amber Turner",
       "flickr_desc": "Artemis II lunar science team member, foreground, Amber Turner, and David Hollibaugh-Baker, and Cherie Achilles, background, participate in the team’s analysis of crew observations during the lunar flyby on April 6, 2026. The team worked in the Science Evaluation Room (SER) in Mission Control at NASA’s Johnson Space Center in Houston. Built specifically for Artemis missions with these science priorities in mind, the SER is equipped to support rapid data interpretation, collaborative analysis, real-time decision making, and seamless coordination between the science and operations teams. Credits: NASA/ Robert Markowitz",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55198608122",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-05 23:28:49",
@@ -1534,7 +2146,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Orientale on Display",
       "flickr_desc": "art002e009212 (April 6, 2026) In this fully illuminated view of the Moon, the near side (the hemisphere we see from Earth), is visible on the right. It is identifiable by the dark splotches that cover its surface. These are ancient lava flows from a time early in the Moon’s history when it was volcanically active. The large crater west of the lava flows is Orientale basin, a nearly 600-mile-wide crater that straddles the Moon’s near and far sides. Orientale's left half is not visible from Earth, but in this image we have a full view of the crater. Everything to the left of the crater is the far side, the hemisphere we don’t get to see from Earth because the Moon rotates on its axis at the same rate that it orbits round us. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55191439024",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-05 23:42:16",
@@ -1550,7 +2168,13 @@ const PHOTO_DATA = {
       "title": "Jeremy Hansen Looks Back Home",
       "flickr_desc": "art002e009272 (April 6, 2026) - Artemis II mission specialist and CSA (Canadian Space Agency) astronaut Jeremy Hansen peers out one of the Orion spacecraft's windows looking back at Earth ahead of the crew's lunar flyby on April 6, 2026. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55191180896",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-05 23:43:29",
@@ -1566,7 +2190,13 @@ const PHOTO_DATA = {
       "title": "Reflections of Earth with Victor Glover",
       "flickr_desc": "art002e009273 (April 6, 2026) - Artemis II pilot and NASA astronaut Victor Glover peers out one of the Orion spacecraft's windows looking back at Earth ahead of the crew's lunar flyby on April 6, 2026. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55191585995",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-05 23:45:53",
@@ -1582,7 +2212,13 @@ const PHOTO_DATA = {
       "title": "Home, Sweet Home",
       "flickr_desc": "art002e009274 (April 6, 2026) - Artemis II mission specialist and NASA astronaut Christina Koch looks out one of the Orion spacecraft's windows back at Earth ahead of the crew's lunar flyby on April 6, 2026. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55190298147",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-05 23:48:55",
@@ -1598,7 +2234,13 @@ const PHOTO_DATA = {
       "title": "Lunar Looking",
       "flickr_desc": "art002e009275 (April 6, 2026) - Artemis II commander and NASA astronaut Reid Wiseman looks out one of the Orion spacecraft's main cabin windows at the Moon ahead of the crew's lunar flyby on April 6, 2026. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55191331293",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 01:45:17",
@@ -1614,7 +2256,13 @@ const PHOTO_DATA = {
       "title": "Goodnight Moon",
       "flickr_desc": "art002e009210 (April 6, 2026) - Before going to sleep on flight day 5, the Artemis II crew snapped one more photo of the Moon, as it drew close in the window of the Orion spacecraft. Orion and the four humans aboard entered the lunar sphere of influence at 12:37 a.m. EDT on April 6, at the tail end of the fifth day of their mission. That marked the point at which the Moon's gravity had a stronger pull on the spacecraft than the Earth's. Artemis II's closest approach to the Moon will come on flight day 6, as they swing around the far side before beginning their journey back to Earth. About an hour after entering the lunar sphere of influence, Artemis II Mission Specialist Christina Koch said, &quot;We are now falling to the Moon rather than rising away from Earth. It is an amazing milestone!&quot; Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55189594357",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 11:25:36",
@@ -1630,7 +2278,13 @@ const PHOTO_DATA = {
       "title": "Even Closer Now",
       "flickr_desc": "art002e009276 (April 6, 2026) - In this view of the Moon, the near side (the hemisphere we see from Earth), is visible at the top half of the Moon disk. It is identifiable by the dark splotches. These are ancient lava flows from a time early in the Moon’s history when it was volcanically active. The large crater that appears below the lava flows, dark in the center, is Orientale basin, a nearly 600-mile-wide crater that straddles the Moon’s near and far sides as is partly visible from Earth on the edge of the Moon. In this image, we have a full view of the crater. Everything below the crater is the far side, the hemisphere we don’t get to see from Earth because the Moon rotates on its axis at the same rate that it orbits round us. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55191470911",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 13:13:00",
@@ -1645,7 +2299,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Playing with Earth-Moon Gravity",
       "flickr_desc": "Out here playing with Earth-Moon gravity like it is a toy and seeing things that are beautiful beyond words. 215,010 miles from Earth. 12,787 miles from the Moon. — via Instagram",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ig-gravity-flyby",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 13:13:31",
@@ -1660,7 +2320,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Final Flyby Preparations",
       "flickr_desc": "art002e009294 (April 6, 2026) – Artemis II Pilot Victor Glover (Left), Commander Reid Wiseman (Center), and Mission Specialist Jeremy Hansen (Right) prepare for their journey around the far side of the Moon by configuring their camera equipment shortly before beginning their lunar flyby observations. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193462360",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 13:33:24",
@@ -1675,7 +2341,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Critical Observations with the Lunar Science Team",
       "flickr_desc": "Crew lunar observations team member, Sara Schmidt, left, asset manager, Luke McSherry, and Artemis deputy lunar science lead, Jacob Richardson work in the Science Evaluation Room (SER). Built specifically for Artemis missions with these science priorities in mind, the SER is equipped to support rapid data interpretation, collaborative analysis, real-time decision making, and seamless coordination between the science and operations teams. Credits: NASA/Luna Posadas Nava",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199650003",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-06 13:54:00",
@@ -1690,7 +2362,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Nutella in Zero-G",
       "flickr_desc": "Nutella flying away in zero gravity, about four minutes before the Artemis II crew broke Apollo 13’s record for the farthest distance from Earth by humans. Behind the far side of the Moon, 252,000+ miles from home. — via Reddit/Instagram",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ig-nutella",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 14:15:12",
@@ -1706,7 +2384,13 @@ const PHOTO_DATA = {
       "title": "A Mesmerizing Moon",
       "flickr_desc": "art002e014195 (April 6, 2026) – NASA astronaut and Artemis II Commander Reid Wiseman pictured here in the Orion spacecraft during the Artemis II lunar flyby. Wiseman and his fellow crewmates spent approximately seven hours taking turns at the Orion windows capturing science data to share with their team back on Earth. At closest approach, they came within 4,067 miles of the Moon’s surface. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55195796542",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 14:15:22",
@@ -1722,7 +2406,13 @@ const PHOTO_DATA = {
       "title": "Window Seat for the Flyby",
       "flickr_desc": "art002e014198 (April 6, 2026) – NASA astronaut and Artemis II Commander Reid Wiseman taking a moment during the seven-hour lunar observation period where the crew reported to the ground team their observations including color nuances, which will help enhance scientific understandings of the Moon. At the beginning of the window, as Orion approaches the Moon on the near side, the side we can see from Earth, people in parts of the eastern hemisphere can view some of the same features the astronauts will observe. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55195796552",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 14:19:17",
@@ -1738,7 +2428,13 @@ const PHOTO_DATA = {
       "title": "Overexposed Moon for Analysis",
       "flickr_desc": "art002e009582 (April 6, 2026) – In this view, most of the Moon’s surface is illuminated as captured by the Artemis II crew during their flyby. To support scientific analysis, the lunar science team requested a series of images of the same scene using different exposure settings—including overexposed, underexposed, and standard images. Each variation highlights different aspects of the surface: brighter exposures can reveal faint features in shadowed regions, while darker exposures help preserve detail in highly reflective areas. Together, these images provide complementary data that allow scientists to better analyze the Moon’s surface composition, texture, and geologic features. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199404085",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 14:19:35",
@@ -1754,7 +2450,13 @@ const PHOTO_DATA = {
       "title": "A Moment with the Moon",
       "flickr_desc": "art002e009277 (April 6, 2026) - In this view of the Moon, taken by the Artemis II crew at 2:19 p.m. EDT, just before the crew began their observation period, Orientale basin is visible in the center, with a black patch of ancient lava in the center that punched through the Moon’s crust in an eruption billions of years ago. This 600-mile-wide impact crater lies along the transition between the near and far sides and is sometimes partly visible from Earth. The small, bright crater to its left is Byrgius, which has 250-mile rays extending out from its basin. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193049251",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 14:22:45",
@@ -1770,7 +2472,13 @@ const PHOTO_DATA = {
       "title": "A Distant Crescent of Home",
       "flickr_desc": "art002e014211 (April 6, 2026) - Seen side by side from deep space, the Moon and Earth share the frame—yet Earth appears as a small, delicate crescent against the blackness beyond. At this stage, Orion is approaching the Moon’s farside, placing the image earlier in the flyby, before closest approach during Artemis II. Though both worlds are visible, the scale and distance between them become immediately clear, offering a powerful perspective of how far the crew has traveled from home. Even in its reduced size, Earth’s soft glow stands out, a reminder of the only world we’ve ever known. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55195413602",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 14:41:43",
@@ -1786,7 +2494,13 @@ const PHOTO_DATA = {
       "title": "Distant Waning Crescent Earth",
       "flickr_desc": "art002e014225 (April 6, 2026) – Seen from afar, Earth appears as a small, delicate waning crescent suspended in the darkness of space, captured by the crew during the Artemis II mission. Only a thin sliver of the planet is illuminated, resembling the familiar crescent phases often seen when observing the Moon from Earth. Despite its distance, faint hints of Earth’s blue tones and cloud patterns are visible, offering a striking perspective of our home planet from deep space. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199312161",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 14:43:49",
@@ -1802,7 +2516,13 @@ const PHOTO_DATA = {
       "title": "A Quiet Moment for Observations",
       "flickr_desc": "art002e014231 (April 6, 2026) – NASA astronaut and Artemis II Commander Reid Wiseman taking a moment during the seven-hour lunar observation period where the crew reported to the ground team their observations including color nuances, which will help enhance scientific understandings of the Moon. At the beginning of the window, as Orion approaches the Moon on the near side, the side we can see from Earth, people in parts of the eastern hemisphere can view some of the same features the astronauts will observe. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55196937384",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 14:44:25",
@@ -1818,7 +2538,13 @@ const PHOTO_DATA = {
       "title": "Crew Scientist",
       "flickr_desc": "art002e009290 (April 6, 2026) – Artemis II Commander Reid Wiseman peers out the window of the Orion spacecraft just as his first lunar observation period of the day begins. Throughout the course of the sixth day of the mission, Wiseman and his crewmates took turns at the windows, capturing images and video of the Moon, along with recorded observations. The astronauts are members of the science team, and the data they collect will shape the future of lunar science. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55192164982",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 14:45:19",
@@ -1833,7 +2559,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Observing the Features of the Moon",
       "flickr_desc": "art002e016130 (April 6, 2026) – NASA astronaut and Artemis II Commander Reid Wiseman pictured here in the Orion spacecraft during the Artemis II lunar flyby. Wiseman and his fellow crewmates spent approximately seven hours taking turns at the Orion windows capturing science data to share with their team back on Earth. At closest approach, they came within 4,067 miles of the Moon’s surface. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55197095290",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 14:48:09",
@@ -1849,7 +2581,13 @@ const PHOTO_DATA = {
       "title": "Capturing the Lunar Flyby from Orion",
       "flickr_desc": "art002e014235 (April 6, 2026) – CSA (Canadian Space Agency) astronaut and Artemis II Mission Specialist Jeremy Hansen is seen taking images through the Orion spacecraft window during the Artemis II lunar flyby. Hansen and his fellow crewmates spent approximately seven hours taking turns at the Orion windows capturing science data to share with their team back on Earth. At closest approach, they came within 4,067 miles of the Moon’s surface. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55197095240",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 14:55:26",
@@ -1864,7 +2602,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Framing the Shot",
       "flickr_desc": "art002e009292 (April 6, 2026) – CSA (Canadian Space Agency) astronaut and Artemis II Mission Specialist Jeremy Hansen is seen taking images through the Orion spacecraft window early in the Artemis II lunar flyby. Hansen and his fellow crewmates spent approximately seven hours taking turns at the Orion windows capturing science data to share with their team back on Earth. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193194643",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:02:00",
@@ -1880,7 +2624,13 @@ const PHOTO_DATA = {
       "title": "A \"Handprint\" on the Moon",
       "flickr_desc": "art002e012010 (April 6, 2026) - Resembling a “handprint” to the Artemis II crew, this view highlights contrasting dark and light features on the Moon’s surface. From top to bottom, the darker regions include Oceanus Procellarum, Mare Humorum—known as the “Sea of Moisture”—and the crater Byrgius A. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194627304",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:04:00",
@@ -1896,7 +2646,13 @@ const PHOTO_DATA = {
       "title": "Ancient Lava on the Moon",
       "flickr_desc": "art002e012028 (April 6, 2026) - The Artemis II crew captured a close-up snapshot of the near side of the Moon as NASA’s Orion spacecraft approached for the lunar flyby. The near side, characterized by the dark patches of ancient lava, is visible on the top third of the lunar disk. Aristarchus crater is the bright white dot in the midst of a dark grey lava flow at the top of the image. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194619544",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:05:44",
@@ -1912,7 +2668,13 @@ const PHOTO_DATA = {
       "title": "Keeper of the Night Sky",
       "flickr_desc": "art002e009278 (April 6, 2026) - Just over half of the Moon fills the left half of the image. The near side, characterized by the dark patches of ancient lava, is visible on the top third of the lunar disk. Orientale basin, a round crater in the center with a black patch of ancient lava in the center, is wrapped in rings of mountains. The round black spot northeast of Orientale is Grimaldi crater, and Aristarchus crater is the bright white dot in the midst of a dark grey lava flow at the top of the image. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193053886",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:06:26",
@@ -1928,7 +2690,13 @@ const PHOTO_DATA = {
       "title": "The Rings of the Orientale Basin",
       "flickr_desc": "art002e012090 (April 6, 2026) - In this view of the Moon, the Artemis II crew captured an intricate snapshot of the rings of the Orientale basin, one of the Moon’s youngest and best-preserved large impact craters on his first shift during the lunar flyby observation period. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194762480",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:06:43",
@@ -1944,7 +2712,13 @@ const PHOTO_DATA = {
       "title": "Vavilov Crater Along the Hertzsprung Basin Rim",
       "flickr_desc": "art002e012093 (April 6, 2026) - Hertzsprung Basin comes into view with its distinctive two concentric rings of mountains, revealing the scale of this ancient impact structure. Near the lower left, Vavilov crater—identified by its central peak—stands out, a feature often described by the Artemis II crew during their lunar flyby. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194361976",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:07:44",
@@ -1960,7 +2734,13 @@ const PHOTO_DATA = {
       "title": "A Cross Section of Lunar Geology",
       "flickr_desc": "A diverse set of lunar features is visible in this view, including the brightly colored Aristarchus crater, whose high reflectivity stands out against the surrounding terrain. Nearby, the Marius Hills region reveals a field of volcanic domes and cones, evidence of past lunar volcanism. The sinuous Reiner Gamma swirl contrasts with the darker mare surface, while rays from Glushko crater streak across the plains. At the bottom of the frame, the dark-floored Grimaldi crater anchors the scene. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194639639",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:08:18",
@@ -1976,7 +2756,13 @@ const PHOTO_DATA = {
       "title": "Seriously Moonstruck",
       "flickr_desc": "art002e012129 (April 6, 2026) - The lower half of the Moon hangs suspended in time in this photograph from the Artemis II crew during the lunar flyby observation period. In the upper center of the photo, the Orientale basin is the prominent feature, with a black patch of ancient lava in the center that punched through the Moon’s crust in an eruption billions of years ago. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194598974",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:09:26",
@@ -1992,7 +2778,13 @@ const PHOTO_DATA = {
       "title": "A Crater of Remembrance",
       "flickr_desc": "art002e012153 (April 6, 2026) - The small, bright spot in the center of the image is the crater that the Artemis II crew have proposed as Carroll, after Commander Reid Wiseman’s late wife. About 3.5 miles across (5.6 km in diameter), the proposed Carroll crater is on the nearside of the lunar surface on the western edge and would be visible from Earth with powerful telescopes. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55195894708",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:11:52",
@@ -2008,7 +2800,13 @@ const PHOTO_DATA = {
       "title": "A Moodier Moon",
       "flickr_desc": "art002e012178 (April 7, 2026) - A shot from early in the Artemis II lunar flyby, taken with a smaller aperture setting, shows a moodier version of the Moon than some of the other flyby images with more typical lighting settings. The four crew members spent about 7 hours photographing and recording observations of the Moon as they flew around the far side on April 6, 2026.",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194768276",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:12:00",
@@ -2023,7 +2821,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Sharing a Unique Perspective",
       "flickr_desc": "art002e014256 (April 6, 2026) – CSA (Canadian Space Agency) astronaut and Artemis II Mission Specialist Jeremy Hansen is seen making observations through the window of the Orion spacecraft early in the Artemis II lunar flyby. Hansen and his fellow crewmates spent approximately seven hours taking turns at the Orion windows capturing science data to share with their team back on Earth. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "art002e014256",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:12:02",
@@ -2039,7 +2843,13 @@ const PHOTO_DATA = {
       "title": "Capture My Good Side – The Moon",
       "flickr_desc": "art002e012183 (April 6, 2026) - On the first shift during the lunar flyby observation period, the Artemis II crew captured more than two-thirds of the Moon showcasing the intricate features of the nearside. The 600-mile-wide impact crater, Orientale basin, lies along the transition between the near and far sides and is sometimes partly visible from Earth. The round black spot northeast of Orientale is Grimaldi crater, known for its exceptionally dark mare lava floor and heavily degraded rim. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194334756",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:18:24",
@@ -2054,7 +2864,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Drawn by the Moon",
       "flickr_desc": "art002e009562 (April 6, 2026) - The Orion spacecraft is seen in the foreground lit up by the Sun. A waxing gibbous Moon is visible in the background. Orientale basin, a 600-mile-wide impact crater ringed by mountains, is visible toward the center bottom of the Moon. This basin straddles the Moon’s near and far sides. To the left of Orientale, which has a patch of ancient lava in its basin, is the far side; this is the hemisphere we don’t get to see from Earth. To the right of Orientale is the near side, the hemisphere we see every day from Earth. The nearside is notable for giant, dark patches of ancient lave flows that cover its surface. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193784989",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:25:21",
@@ -2070,7 +2886,13 @@ const PHOTO_DATA = {
       "title": "A Tapestry of Lunar Landmarks",
       "flickr_desc": "art002e012261 (April 6, 2026) - Multiple lunar landmarks come into view in this image, many of which were highlighted during the Artemis II crew’s observation call. Visible features include Ohm crater, Oceanus Procellarum, Grimaldi crater, Pierazzo crater, the newly proposed Carroll crater, and the expansive Hertzsprung Basin—together illustrating a range of geologic terrains, from dark volcanic plains to heavily cratered highlands and the remnants of ancient impact basins.",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194529188",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:28:57",
@@ -2086,7 +2908,13 @@ const PHOTO_DATA = {
       "title": "Swoon at the Moon",
       "flickr_desc": "art002e012273 (April 6, 2026) - This view of the southwest portion of Orientale Basin highlights its prominent annular ring—a sweeping arc of mountainous terrain formed by the immense energy of an ancient impact. The ring structure rises above the surrounding surface, tracing the basin’s outer boundary and revealing the layered, multi-ring nature of one of the Moon’s most well-preserved impact features. Apollo-era observers nicknamed this formation “the kiss,” reflecting its distinctive, curved shape. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194627309",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:34:27",
@@ -2102,7 +2930,13 @@ const PHOTO_DATA = {
       "title": "Dark Craters, Bright Views",
       "flickr_desc": "art002e009627 (April 6, 2026) – During the first shift of the lunar flyby observation period, the Artemis II crew captured more than two-thirds of the Moon, highlighting surface details on the nearside, including the 600-mile-wide impact crater, Orientale basin, along the boundary between the near and far sides. They also captured the Grimaldi crater, a dark, round feature northeast of Orientale, known for its dark mare lava floor and heavily worn rim. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55196010752",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:41:45",
@@ -2118,7 +2952,13 @@ const PHOTO_DATA = {
       "title": "It's All in the Details",
       "flickr_desc": "art002e009279 (April 6, 2026) – During their lunar flyby observation period, the Artemis II crew captured this image at 3:41 p.m. EDT, showing the rings of the Orientale basin, one of the Moon’s youngest and best-preserved large impact craters. These concentric rings offer scientists a rare window into how massive impacts shape planetary surfaces, helping refine models of crater formation and the Moon’s geologic history. At the 10 o’clock position of the Orientale basin, the two smaller craters – which the Artemis II crew has suggested be named Integrity and Carroll – are visible. These features highlight how crew observations can directly support surface feature identification and real-time science. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193206753",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:46:20",
@@ -2134,7 +2974,13 @@ const PHOTO_DATA = {
       "title": "Crossing into the Lunar Farside",
       "flickr_desc": "art002e010014 (April 6, 2026) – A bright portion of the Moon is visible in this image. If you look closely, you can see linear, pitted features known as “crater chains” radiating from the Orientale basin, an impact crater with a patch of ancient lava at its center, visible in the bottom center of the image. These crater chains formed about 3.8 billion years ago, when rocks spewed from the collision that formed Orientale landed in lines extending away from the crater. These chains are found near other large craters on the Moon, but we don’t get to see them on Earth because our planet’s crust has been turned over so many times through plate tectonics and largely erased by rain, wind, and ice. In the upper left corner of the Moon disk is a line called the terminator, the boundary between lunar day and night. Here, low-angle sunlight skims the surface, casting dramatic shadows that expose the area’s topography — or the shape of its surface. Glushko crater is the bright spot just to the left of the dark mare, or “sea” of ancient lava flows on the near side of the Moon. It’s identifiable by the bright rays that shoot across the mare, some hundreds of miles away. These rays are made of ejected material after the collision that formed Glushko. Glushko and its rays are brighter than the surrounding area because that younger has experienced less weathering from radiation and impacts. Oceanus Procellarum, the largest lava-filled region on the Moon, spans the horizon. The Aristarchus crater, the bright spot in the sea of lava, creeps toward the right edge of the Moon. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55197995935",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:57:39",
@@ -2149,7 +2995,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Lunar Flyby Observations – Victor Glover and Christina Koch",
       "flickr_desc": "art002e016195 (April 6, 2026) – Artemis II Pilot Victor Glover, on the left, and Mission Specialist Christina Koch, on the right, gather images and observations of the lunar surface to share with the world during the lunar flyby on the sixth day of the mission. The crew spent approximately seven hours taking turns at the windows of the Orion spacecraft as they flew around the far side of the Moon. At closest approach, they came within 4,067 miles of the Moon’s surface. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55196704886",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 15:59:12",
@@ -2164,7 +3016,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Lunar Flyby Observations – Victor Glover",
       "flickr_desc": "art002e016204 (April 6, 2026) – NASA astronaut and Artemis II Pilot Victor Glover pictured here in the Orion spacecraft during the Artemis II lunar flyby. Glover and his fellow crewmates spent approximately seven hours taking turns at the Orion windows capturing science data to share with their team back on Earth. At closest approach, they came within 4,067 miles of the Moon’s surface. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55196961359",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 16:05:00",
@@ -2179,7 +3037,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Lunar Flyby Observations – Reid Wiseman",
       "flickr_desc": "art002e016165 (April 6, 2026) – NASA astronaut and Artemis II Commander Reid Wiseman pictured here in the Orion spacecraft during the Artemis II lunar flyby. Wiseman and his fellow crewmates spent approximately seven hours taking turns at the Orion windows capturing science data to share with their team back on Earth. At closest approach, they came within 4,067 miles of the Moon’s surface. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "art002e016165",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 16:10:00",
@@ -2194,7 +3058,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Lunar Flyby Observations – Jeremy Hansen",
       "flickr_desc": "art002e016171 (April 6, 2026) – CSA (Canadian Space Agency) astronaut and Artemis II Mission Specialist Jeremy Hansen pictured here in the Orion spacecraft during the Artemis II lunar flyby. Hansen and his fellow crewmates spent approximately seven hours taking turns at the Orion windows capturing science data to share with their team back on Earth. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "art002e016171",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 16:15:00",
@@ -2209,7 +3079,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Lunar Flyby Observations – Christina Koch",
       "flickr_desc": "art002e016172 (April 6, 2026) – NASA astronaut and Artemis II Mission Specialist Christina Koch pictured here in the Orion spacecraft during the Artemis II lunar flyby. Koch and her fellow crewmates spent approximately seven hours taking turns at the Orion windows capturing science data to share with their team back on Earth. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "art002e016172",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 16:25:43",
@@ -2224,7 +3100,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Choreographed Camera Work",
       "flickr_desc": "art002e009293 (April 6, 2026) – Artemis II Pilot Victor Glover, on the left, and Mission Specialist Christina Koch, on the right, gather images and observations of the lunar surface to share with the world during the lunar flyby on the sixth day of the mission. The crew spent approximately seven hours taking turns at the windows of the Orion spacecraft as they flew around the far side of the Moon. At closest approach, they came within 4,067 miles of the Moon’s surface. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193069001",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 16:32:20",
@@ -2239,7 +3121,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Fist Pump at the CAPCOM Console",
       "flickr_desc": "A flight controller pumps his fist in celebration at his console in Mission Control during the Artemis II lunar flyby. The gesture captures a moment of triumph as the crew approaches the Moon.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55209951780",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-06 17:11:22",
@@ -2254,7 +3142,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "A Moment of Awe in Mission Control",
       "flickr_desc": "A member of the mission support team looks up with quiet emotion during the Artemis II lunar flyby, the Moon visible on a screen behind him. His expression captures the profound significance of humanity's return to the Moon.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55207655441",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-06 17:27:20",
@@ -2270,7 +3164,13 @@ const PHOTO_DATA = {
       "title": "The Moon's Cratered Southern Highlands",
       "flickr_desc": "A black-and-white view of the Moon's heavily cratered southern hemisphere, photographed from the Orion spacecraft during the Artemis II flyby. The stark lighting reveals the depth and texture of ancient impact craters across the lunar highlands.",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55207935871",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 17:30:00",
@@ -2285,7 +3185,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Photographer at Work",
       "flickr_desc": "art002e009295 (April 6, 2026) – Astronaut Jeremy Hansen captures an image through the camera shroud covering window 2 of the Orion spacecraft. The camera shroud, essentially a curtain with a hole for the lens to pass through, is used to prevent light from the cabin from reflecting on the windowpanes. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193337359",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 17:44:27",
@@ -2301,7 +3207,13 @@ const PHOTO_DATA = {
       "title": "The Edge of Darkness",
       "flickr_desc": "art002e010208 (April 6, 2026) - As the Artemis II crew flew over the terminator, the astronauts described this boundary between day and night as &quot;anything but a straight line.&quot; Crater rims along the terminator stand out as &quot;islands&quot; in the night. Giant chains of craters emanating from the 3.7-billion-year-old Orientale basin can be seen scouring the surface, stretching almost to the terminator. This tells a geologic story: these crater chains produced by the Orientale impact event mar the surface of the relatively flat Hertzsprung Basin (center of this image), which means that Hertzsprung Basin must be even older than Orientale! Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55196075694",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 17:45:04",
@@ -2317,7 +3229,13 @@ const PHOTO_DATA = {
       "title": "The Moon's Great Scar",
       "flickr_desc": "art002e010232 (April 6, 2026) – During the lunar flyby observation period, the Artemis II crew captures a detailed image of the Orientale basin, a 600-mile-wide impact crater marked by a dark patch of ancient lava that erupted through the Moon’s crust billions of years ago. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55197007576",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 17:46:35",
@@ -2333,7 +3251,13 @@ const PHOTO_DATA = {
       "title": "Shadows at the Edge of Lunar Day",
       "flickr_desc": "art002e009281 (April 6, 2026) – The Artemis II crew captures a portion of the Moon coming into view along the terminator – the boundary between lunar day and night – where low-angle sunlight casts long, dramatic shadows across the surface. This grazing light accentuates the Moon’s rugged topography, revealing craters, ridges, and basin structures in striking detail. Features along the terminator such as Jule Crater, Birkhoff Crater, Stebbins Crater, and surrounding highlands stand out. From this perspective, the interplay of light and shadow highlights the complexity of the lunar surface in ways not visible under full illumination. The image was captured about three hours into the crew’s lunar observation period, as they flew around the far side of the Moon on the sixth day of the mission. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193137293",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 17:49:02",
@@ -2349,7 +3273,13 @@ const PHOTO_DATA = {
       "title": "Craters of Time",
       "flickr_desc": "art002e010399 (April 6, 2026) – During a lunar flyby observation period, the Artemis II crew captures craters dotting the surface of the Moon, revealing its rugged, ancient surface. This scarred landscape reflects a long history of cosmic collisions. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55197552725",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 17:49:43",
@@ -2365,7 +3295,13 @@ const PHOTO_DATA = {
       "title": "Shadows Across Vavilov Crater",
       "flickr_desc": "A close-up view taken by the Artemis II crew of Vavilov Crater on the rim of the older and larger Hertzsprung basin. The right portion of the image shows the transition from smooth material within an inner ring of mountains to more rugged terrain around the rim. Vavilov and other craters and their ejecta are accentuated by long shadows at the terminator, the boundary between lunar day and night. The image was captured with a handheld camera at a focal length of 400 mm, as the crew flew around the far side of the Moon. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193002296",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 17:50:25",
@@ -2380,7 +3316,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Orion in the Spotlight",
       "flickr_desc": "art002e009566 (April 6, 2026) - NASA’s Orion spacecraft is seen in the foreground, lit up by the Sun. A first quarter Moon is visible behind it, with sunlight coming from the right. Near the bottom right edge of the Moon, Orientale basin stands out with a black patch of ancient lava in its center. A 600-mile-wide impact crater ringed by mountains, Orientale straddles the near and far sides of the Moon. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193946135",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 17:58:14",
@@ -2396,7 +3338,13 @@ const PHOTO_DATA = {
       "title": "Ready for a Close Up",
       "flickr_desc": "art002e009283 (April 6, 2026) – Captured by the Artemis II crew, the heavily cratered terrain of the eastern edge of the South Pole-Aitken basin is seen with the shadowed terminator – the boundary between lunar day and night – at the top of the image. The South Pole-Aitken basin is the largest and oldest basin on the Moon, providing a glimpse into an ancient geologic history built up over billions of years. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193149063",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:02:22",
@@ -2411,7 +3359,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Lunar Selfie",
       "flickr_desc": "art002e009296 (April 6, 2026) – Midway through their lunar observation period, the Artemis II crew members, seen here (From left to right: Victor Glover, Jeremy Hansen, Reid Wiseman, and Christina Koch), pause to turn the camera around for a selfie inside the Orion spacecraft. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193071311",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:05:33",
@@ -2427,7 +3381,13 @@ const PHOTO_DATA = {
       "title": "Earthset Over the Lunar Limb",
       "flickr_desc": "Earth appears tiny as the Moon looms large in this photo taken by the Artemis II crew during their lunar flyby on April 6, 2026. Taken 36 minutes before Earthset, our home planet is visible in the blackness of space off the limb of the illuminated Moon. Earth is in a crescent phase, with sunlight coming from the right. Orientale mare basin, with its dark floor of cooled lava and outer rings of mountains, covers nearly the lower third of the imaged lunar surface. Different colors in the mare hint at its mineral composition. The lines of small indentations above Orientale are secondary crater chains, formed by material ejected during a violent primary impact. Both of the new craters that the Artemis II crew has suggested names for – Integrity and Carroll – are in full view. The edge of the visible surface of the Moon is called the “lunar limb.” Seen from afar, it almost looks like a circular arc – except when backlit, as in other images captured by the Artemis II crew. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193414680",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:10:17",
@@ -2442,7 +3402,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Still Life",
       "flickr_desc": "art002e012278 (April 6, 2026) - The Moon seen peeking above the window sill of the Orion spacecraft during the Artemis II lunar flyby on April 6, 2026. The Artemis II crew spent about 7 hours at the Orion windows during the flyby, taking photos and recording observations on the Moon to share with scientists on the ground.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194917013",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:32:05",
@@ -2457,7 +3423,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "A Room With a View",
       "flickr_desc": "art002e012279 (April 6, 2026) - A view from the window of the Orion spacecraft approximately 9 minutes before Earthset during the Artemis II lunar flyby on April 6, 2026.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55195026049",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:33:15",
@@ -2473,7 +3445,13 @@ const PHOTO_DATA = {
       "title": "Lunar Horizon at an Angle",
       "flickr_desc": "The cratered lunar surface stretches diagonally across the frame, with the horizon cutting from lower-left to upper-right. Taken during the closest approach phase of the Artemis II flyby, the image shows the rugged far side terrain in sharp detail.",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55206722770",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:33:35",
@@ -2488,7 +3466,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Moon's Farside in the Foreground, Earth Beyond",
       "flickr_desc": "Seen from behind the Moon during Artemis II, the Moon and Earth align in the same frame, each partially illuminated by the Sun. The Moon’s surface appears in sharp detail in the foreground, while Earth sits much farther away, smaller and softly lit in the background. A faint reflection in the spacecraft window is also visible, subtly overlaying the scene. Though their phases differ, both are shaped by the same sunlight, revealing the geometry of the Sun–Earth–Moon system from deep space. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55196453768",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:33:44",
@@ -2503,7 +3487,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Crescent Earth Over Lunar Horizon",
       "flickr_desc": "art002e015231 (April 6, 2026) – The Artemis II crew captures a faint view of a crescent Earth above the horizon on the Moon’s far side. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55197737178",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:35:54",
@@ -2519,7 +3509,13 @@ const PHOTO_DATA = {
       "title": "The Edge of Two Worlds",
       "flickr_desc": "art002e009285 (April 6, 2026) – Our planet draws closer to passing behind the Moon in this image captured by the Artemis II crew during their lunar flyby, about six minutes before Earthset. Earth is in a crescent phase, with sunlight coming from the right. The dark portion of Earth is experiencing nighttime. On Earth’s day side, swirling clouds are visible over muted blue in the Australia and Oceania region. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55192123432",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:35:56",
@@ -2534,7 +3530,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Science Officers in Mission Control",
       "flickr_desc": "jsc2026e020490 (April 6, 2026) - Pictured from left to right, Angela Garcia, Dr. Kelsey Young, and Dr. Trevor Graff, the first science officers of the Artemis program in the White Flight Control Room in the Christopher C. Kraft Jr. Mission Control Center at NASA’s Johnson Space Center. Seen here about ten minutes before Earthset during Artemis II, these science officers are seen monitoring mission data in real-time from the Science console. They support flight controllers by analyzing scientific measurements and system performance. Their work helps ensure mission objectives are achieved safely and efficiently. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193368072",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-06 18:39:44",
@@ -2549,7 +3551,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Orion Selfie with Crescent Moon and Earth",
       "flickr_desc": "A GoPro camera mounted on Orion's solar array wing captures the spacecraft's service module in the foreground with a crescent Moon and a tiny crescent Earth visible in the background. The NASA logo is clearly visible on the spacecraft's exterior.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55206394005",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:40:29",
@@ -2565,7 +3573,13 @@ const PHOTO_DATA = {
       "title": "Earthrise Behind the Lunar Limb",
       "flickr_desc": "A crescent Earth peeks out from behind the Moon's cratered limb in this stunning telephoto image from the Artemis II flyby. The Moon's surface fills most of the frame, its craters and highlands sharply rendered, while Earth's familiar blue-and-white crescent hangs just beyond the horizon.",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55208655682",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:40:47",
@@ -2581,7 +3595,13 @@ const PHOTO_DATA = {
       "title": "Peeking at the Earth",
       "flickr_desc": "art002e009286 (April 6, 2026) – As the Artemis II crew came close to passing behind the Moon and experiencing a planned loss of signal, they captured this image of a crescent Earth setting on the Moon’s limb. The edge of the visible surface of the Moon is called the “lunar limb.” Seen from afar, it almost looks like a circular arc – except when backlit, as in other images captured by the Artemis II crew. In this photo, the dark portion of Earth is experiencing nighttime, while Australia and Oceania are in the daylight. In the foreground, the Ohm crater is visible, with terraced edges and a flat floor interrupted by central peaks—formed when the surface rebounded upward during the impact that created the crater. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193180468",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:41:22",
@@ -2597,7 +3617,13 @@ const PHOTO_DATA = {
       "title": "A New View of the Moon",
       "flickr_desc": "art002e009287 (April 6, 2026) – Earth sets at 6:41 p.m. EDT, April 6, 2026, over the Moon’s curved limb in this photo captured by the Artemis II crew during their journey around the far side of the Moon. Orientale basin is perched on the edge of the visible lunar surface. Hertzsprung Basin appears as two subtle concentric rings, which are interrupted by Vavilov, a younger crater superimposed over the older structure. The lines of indentations are secondary crater chains formed by ejecta from the massive impact that created Orientale. The dark portion of Earth is experiencing nighttime. On Earth’s day side, swirling clouds are visible over the Australia and Oceania region. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55192132107",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:41:37",
@@ -2613,7 +3639,13 @@ const PHOTO_DATA = {
       "title": "Earthset",
       "flickr_desc": "art002e009288 (April 6, 2026) – Earthset captured through the Orion spacecraft window at 6:41 p.m. EDT, April 6, 2026, during the Artemis II crew’s flyby of the Moon. A muted blue Earth with bright white clouds sets behind the cratered lunar surface. The dark portion of Earth is experiencing nighttime. On Earth’s day side, swirling clouds are visible over the Australia and Oceania region. In the foreground, Ohm crater has terraced edges and a flat floor interrupted by central peaks—formed when the surface rebounded upward during the impact that created the crater. Image Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55192084847",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:41:58",
@@ -2629,7 +3661,13 @@ const PHOTO_DATA = {
       "title": "Earthrise Over the Lunar Far Side",
       "flickr_desc": "Earth rises above the Moon's far side horizon, appearing as a small blue-white crescent above the grey expanse of the lunar surface. The image captures one of the most iconic views in spaceflight — our home planet seen from the vicinity of another world.",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55208327975",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:41:58",
@@ -2645,7 +3683,13 @@ const PHOTO_DATA = {
       "title": "A Setting Earth",
       "flickr_desc": "art002e009289 (April 6, 2026) – The lunar surface fills the frame in sharp detail, as seen during the Artemis II lunar flyby, while a distant Earth sets in the background. This image was captured at 6:41 p.m. EDT, on April 6, 2026, just three minutes before the Orion spacecraft and its crew went behind the Moon and lost contact with Earth for 40 minutes before emerging on the other side. In this image, the dark portion of Earth is experiencing nighttime, while on its day side, swirling clouds are visible over the Australia and Oceania region. In the foreground, Ohm crater shows terraced edges and a relatively flat floor marked by central peaks — formed when the surface rebounded upward during the impact that created the crater. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193178333",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:42:14",
@@ -2660,7 +3704,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Orion POV: Destination and Home",
       "flickr_desc": "art002e009567 (April 6, 2026) - NASA’s Orion spacecraft captures the Moon and the Earth in one frame during the Artemis II crew’s deep space journey at 6:42 p.m. ET on the sixth day of the mission. The right side of NASA’s Orion spacecraft is seen lit up by the Sun. A waxing crescent Moon is visible behind it. And then, a crescent Earth, tiny compared to the Moon, is about to set below the Moon’s horizon on the right. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55192657082",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:42:30",
@@ -2675,7 +3725,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Only One Chance in This Lifetime",
       "flickr_desc": "Only one chance in this lifetime… Like watching sunset at the beach from the most foreign seat in the house. This video captures Earth setting behind the Moon during the Artemis II lunar flyby. — Reid Wiseman via Instagram",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ig-earthset-wiseman",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:42:42",
@@ -2691,7 +3747,13 @@ const PHOTO_DATA = {
       "title": "A Breathtaking Earthset from Orion",
       "flickr_desc": "art002e021278 (April 6, 2026) – Echoing the iconic Earthrise photo captured by the Apollo 8 astronauts in 1968, during the lunar flyby, the Artemis II crew captured a shot of Earthset as they passed behind the Moon’s far side. It is one of many photos taken during the seven-hour lunar flyby by the Artemis II crew on the Orion spacecraft. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55198598917",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:42:45",
@@ -2707,7 +3769,13 @@ const PHOTO_DATA = {
       "title": "Taking a Peek at Earth from the Far Side of the Moon",
       "flickr_desc": "art002e021283 (April 6, 2026) – The Earth appears to be peeking out over the horizon of the Moon,but pictured here is actually an Earthset. During an Earthset, the planet appears to sink below the lunar horizon. In this scene, a partially lit crescent Earth drops behind the Moon as seen by crew on the Orion spacecraft. The image also shows the vast canvas of the Moon’s surface with its overlapping craters and basins. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55198687567",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:42:52",
@@ -2723,7 +3791,13 @@ const PHOTO_DATA = {
       "title": "Hertzsprung in Light and Shadow",
       "flickr_desc": "art002e021296 (April 6, 2026) – As the Artemis II crew flew around the far side of the Moon, they captured key scientific observations, photographs, videos, and records documenting critical observations to help scientists on the ground understand the composition and history of the lunar surface. Near the center of the view lies Hertzsprung basin, an ancient and expansive impact feature described by the Artemis II crew as darker in overall tone compared to surrounding terrain. Crew observations highlight a striking contrast in texture: the interior of Hertzsprung appears unusually smooth, “like a paved road,” while the outer regions transition into rougher, more jagged terrain. Subtle variations in brightness and color across the basin create a patchwork of lighter and darker areas, offering clues to its complex geologic history. Surrounding regions show evidence of ejecta and crater rays, with faint brownish and gray tones radiating across the highlands. Together, these features provide a dynamic view of one of the Moon’s oldest and most intriguing basins. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199984595",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 19:01:17",
@@ -2739,7 +3813,13 @@ const PHOTO_DATA = {
       "title": "Over the Moon, Bea",
       "flickr_desc": "art002e012632 (April 6, 2026) - The Artemis II crew captures the Moon's curved limb during their journey around the far side of the Moon. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55196710272",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 19:02:32",
@@ -2755,7 +3835,13 @@ const PHOTO_DATA = {
       "title": "A Terrain of Ancient Impacts",
       "flickr_desc": "art002e012673 (April 6, 2026) – As the Artemis II crew passes the Moon during an observation period, the lunar landscape sharpens into focus: a terrain scattered with craters and shadows stretching beneath the black expanse of space. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199774765",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 19:03:06",
@@ -2771,7 +3857,13 @@ const PHOTO_DATA = {
       "title": "Poynting and Keeler Craters on the Lunar Far Side",
       "flickr_desc": "art002e012702 (April 6, 2026) – Poynting crater and Keeler crater are visible side by side in the lower right portion of this image of the Moon’s far side highlands. Poynting, positioned above, is a large impact crater with a well-defined rim and relatively smooth interior, indicative of material that has settled following the initial impact. Just below it, Keeler crater appears slightly smaller, with a sharply outlined rim and a more textured interior shaped by subsequent impacts and ejecta. Both features lie within the densely cratered far side highlands, preserving a record of ancient impacts that have shaped the lunar surface over billions of years. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55198362617",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 19:03:30",
@@ -2787,7 +3879,13 @@ const PHOTO_DATA = {
       "title": "Birkhoff Crater in Low-Light Detail",
       "flickr_desc": "art002e012723 (April 6, 2026) – A close-up view of the Birkhoff crater on the Moon’s far side, captured by the Artemis II crew, shows the surface under low-light conditions. Located within the lunar highlands, Birkhoff is an impact crater shaped by billions of years of collisions. In this underexposed image, reduced brightness reveals subtle variations in texture and topography that are often less visible in brighter views. The lighting emphasizes differences in surface roughness and ejecta patterns, providing a clearer look at the crater’s structure and the surrounding terrain. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199141754",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 19:09:19",
@@ -2803,7 +3901,13 @@ const PHOTO_DATA = {
       "title": "The Lunar Terminator at Close Range",
       "flickr_desc": "The boundary between day and night on the Moon's surface — the terminator — cuts diagonally across the frame, with crater rims catching the last rays of sunlight while the rest falls into deep shadow. Taken at close range during the Artemis II flyby.",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55204753657",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 19:09:30",
@@ -2819,7 +3923,13 @@ const PHOTO_DATA = {
       "title": "Craters Along the Lunar Terminator",
       "flickr_desc": "art002e014055 (April 6, 2026) - A close-up view of the Moon along the terminator—the boundary between lunar day and night—captured by the crew during the Artemis II mission. The low-angle sunlight on this specific day casts long shadows across the surface, revealing the shape and depth of craters in striking detail. Since the early days of the telescope, astronomers used observations along the terminator to map the Moon’s terrain, taking advantage of the contrast between light and shadow to distinguish surface features. While modern imaging has advanced significantly, this lighting still provides valuable insight into the Moon’s topography. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55198256277",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 19:22:30",
@@ -2835,7 +3945,13 @@ const PHOTO_DATA = {
       "title": "Artemis Era Earthrise",
       "flickr_desc": "art002e009280 (April 6, 2026) – Earthrise captured through the Orion spacecraft window at 7:22 p.m. ET during the Artemis II crew’s flyby of the Moon’s far side. Earth appears as a delicate crescent, with only its upper edge illuminated. The planet’s soft blue hue and scattered white cloud systems stand out against the blackness of space, while the lower portion fades into night. Taken with a 400 mm lens, the image, Earthrise, reveals a striking alignment of Earth and Moon, with the Moon in the top foreground and the Earth below. Along the lunar horizon, rugged terrain is silhouetted against the bright crescent Earth. Both bodies are oriented with their north poles to the left and south poles to the right, offering a unique perspective of our home planet from deep space. This photo was rotated 90 degrees clockwise for standard viewing orientation. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193054686",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 19:22:44",
@@ -2850,7 +3966,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Orion, Earth, and Moon from the Solar Array",
       "flickr_desc": "A GoPro mounted on Orion's solar array captures the spacecraft's service module in the foreground with a tiny crescent Earth visible in the distance and the faintly lit lunar surface at the edge of the frame. The NASA worm logo is visible on the adapter ring.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55207839868",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 19:23:16",
@@ -2866,7 +3988,13 @@ const PHOTO_DATA = {
       "title": "Earth's Crescent from Lunar Orbit",
       "flickr_desc": "art002e014066 (April 6, 2026) – The Artemis II crew captures an image of a crescent Earth on their journey around the Moon. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199812540",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 20:35:31",
@@ -2882,7 +4010,13 @@ const PHOTO_DATA = {
       "title": "A Solar Eclipse Like No Other",
       "flickr_desc": "art002e010782 (April 6, 2026) - In this view captured by the Artemis II crew on the Orion spacecraft, a wedge of the Moon in nighttime is visible in the foreground, as the Sun is setting on the opposite side. This image captures the beginning of a total solar eclipse that astronauts were able to observe at the end of their lunar observation period during Orion’s closest approach to the Moon on April 6, 2026. Unlike minutes-long eclipses as viewed from Earth, the Artemis II crew witnessed the Sun hide behind the Moon for nearly an hour. Because the astronauts were so near the Moon, it appeared much larger than the Sun; because of this, it took longer for the Sun to make its transit across the Moon and peek out the other side. From Earth, in contrast, the Moon and Sun appear about the same size, so even small changes in their alignment quickly bring the Sun back into view, making totality much shorter. The bright rays of light, or streamers, that are running outward towards the bottom of the Moon disk are part of the Sun's corona. The corona is the outermost layer of the Sun's atmosphere and is only visible during a total solar eclipse. It is normally hidden by the bright light of the Sun's surface. In addition, the jagged edge of the Moon visible in this image reveals the topography of backlit mountains on the horizon. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55197506830",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 20:40:54",
@@ -2897,7 +4031,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Solar Eclipse from the Far Side",
       "flickr_desc": "The Sun is fully eclipsed by the Moon as seen from the Orion spacecraft during the Artemis II flyby. The Moon's dark disk is surrounded by a brilliant halo of light — the Sun's corona and possibly zodiacal light — with stars visible in the background. The crew witnessed nearly 54 minutes of totality from this vantage point.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55207787628",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 21:01:20",
@@ -2913,7 +4053,13 @@ const PHOTO_DATA = {
       "title": "Artemis II Total Solar Eclipse, Partial Frame",
       "flickr_desc": "art002e009298 (April 6, 2026) – A close-up view from the Orion spacecraft during the Artemis II crew’s lunar flyby on April 6, 2026, captures a total solar eclipse, with only part of the Moon visible in the frame as it fully obscures the Sun. We see a glowing halo around the dark lunar disk. The science community is investigating whether this effect is due to the corona, zodiacal light, or a combination of the two. From this deep-space vantage point, the Moon appeared large enough to sustain nearly 54 minutes of totality, far longer than total solar eclipses typically seen from Earth. The bright silver glint on the left edge of the image is the planet Venus. The round, dark gray feature visible along the Moon’s horizon between the 9 and 10 o’clock positions is Mare Crisium, a feature visible from Earth. We see faint lunar features because light reflected off of Earth provides a source of illumination. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55192173787",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 21:05:29",
@@ -2928,7 +4074,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Eclipsed Moon with Corona Glow",
       "flickr_desc": "The Moon's full disk appears in silhouette against the Sun's glowing corona during the total solar eclipse witnessed by the Artemis II crew. The corona's ethereal light radiates outward from behind the Moon, with faint surface features visible through Earthshine. Stars dot the surrounding darkness.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55208682757",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 21:06:19",
@@ -2943,7 +4095,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II in Eclipse",
       "flickr_desc": "art002e009301 (April 6, 2026) – Captured by the Artemis II crew during their lunar flyby on April 6, 2026, this image shows the Moon fully eclipsing the Sun. From the crew’s perspective, the Moon appears large enough to completely block the Sun, creating nearly 54 minutes of totality and extending the view far beyond what is possible from Earth. We see a glowing halo around the dark lunar disk. The science community is investigating whether this effect is due to the corona, zodiacal light, or a combination of the two. Also visible are stars, typically too faint to see when imaging the Moon, but with the Moon in darkness stars are readily imaged. This unique vantage point provides both a striking visual and a valuable opportunity for astronauts to document their observations during humanity’s return to deep space. The faint glow of the nearside of the Moon is visible in this image, having been illuminated by light reflected off the Earth. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193054741",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 21:10:44",
@@ -2958,7 +4116,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Eclipsed: A View from Orion",
       "flickr_desc": "art002e009571 (April 6, 2026) - The Moon, backlit by the Sun during a solar eclipse, is photographed by NASA’s Orion spacecraft on April 6, 2026, during the Artemis II mission. Orion is visible in the foreground on the left. Earth is reflecting sunlight at the left edge of the Moon, which is slightly brighter than the rest of the disk. The bright spot visible just below the Moon’s bottom right edge is Saturn. Beyond that, the bright spot at the right edge of the image is Mars. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193566011",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 21:11:49",
@@ -2973,7 +4137,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Solar Eclipse of the Heart",
       "flickr_desc": "art002e009573 (April 6, 2026) - The Moon, seen here backlit by the Sun during a solar eclipse on April 6, 2026, is photographed by one of the cameras on the Orion spacecraft’s solar array wings. Orion is visible in the foreground on the left. Earth is reflecting sunlight at the left edge of the Moon, which is slightly brighter than the rest of the disk. The bright spot visible just below the Moon’s bottom right edge is Saturn. Beyond that, the bright spot at the right edge of the image is Mars. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55192683067",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 21:28:36",
@@ -2989,7 +4159,13 @@ const PHOTO_DATA = {
       "title": "Solar Eclipse Emergence from Orion",
       "flickr_desc": "art002e009299 (April 6, 2026) – Captured from the Orion spacecraft near the end of the Artemis II lunar flyby on April 6, this image shows the Sun beginning to peek out from behind the Moon as the eclipse transitions out of totality. Only a portion of the Moon is visible in frame, its curved edge revealing a bright sliver of sunlight returning after nearly an hour of darkness. In final moments of the eclipse observed by the crew, the reemerging light creates a sharp contrast against the Moon’s silhouette and reveals lunar topography not usually visible along the lunar limb. This fleeting phase captures the dynamic alignment of the Sun, Moon, and spacecraft as Orion continues its journey back from the far side of the Moon. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193207303",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 21:28:39",
@@ -3004,7 +4180,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "A Sunrise for Orion",
       "flickr_desc": "art002e009575 (April 6, 2026) - The Sun is rising at the left edge of the Moon, ending a nearly one-hour total solar eclipse on April 6, 2026. While the Sun hid behind the Moon, the crew aboard the Orion spacecraft, pictured in the forefront, saw a Moon shrouded in night. This offered a perfect opportunity to look for rarely seen phenomena. And the moment delivered. Calling down to Earth at 9 p.m. ET the crew reported seeing six impact flashes, which are light flashes that are created when meteoroids, traveling many thousands of miles per hour, smash into the Moon’s surface. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193828029",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 21:32:01",
@@ -3019,7 +4201,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Eclipse Safety First",
       "flickr_desc": "art002e009302 (April 6, 2026) – The Artemis II crew – Mission Specialist Christina Koch (top left), Mission Specialist Jeremy Hansen (bottom left), Commander Reid Wiseman (bottom right), and Pilot Victor Glover (top right) – uses eclipse viewers, identical to what NASA produced for the 2023 annular eclipse and 2024 total solar eclipse, to protect their eyes at key moments during the solar eclipse they experienced during their lunar flyby. This was the first use of eclipse glasses at the Moon to safely view a solar eclipse. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193207308",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 21:44:32",
@@ -3034,7 +4222,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Lunar Flyby in Mission Control",
       "flickr_desc": "jsc2026e020501 (April 6, 2026) - NASA Flight Directors Diane Dailey, Pooja Jesrani, and Paul Konyha pictured in the White Flight Control Room during the Artemis II crew’s lunar flyby. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194399918",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-06 22:38:25",
@@ -3049,7 +4243,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Presidential Call",
       "flickr_desc": "jsc2026e020504 (April 6, 2026) - The Artemis II crew – CSA (Canadian Space Agency) Astronaut Jeremy Hansen (far left) and NASA astronauts Christina Koch (center left), Reid Wiseman (center right), and Victor Glover (right) – pauses to wave after a live conversation with President Donald J. Trump following their historic lunar flyby during Flight Day 6. They are pictured on the screens of the White Flight Control room at NASA’s Mission Control Center at the agency’s Johnson Space Center in Houston. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194659885",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-07 08:27:53",
@@ -3064,7 +4264,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Details of Orion",
       "flickr_desc": "art002e012476 (April 7, 2026) - Solar array wing-mounted cameras capture close-up images of NASA’s Orion spacecraft during a routine external inspection on the sixth day into the Artemis II mission. At the time this photo was taken at 8:27 a.m. ET, the crew was in a sleep period ahead of beginning their seventh day into the mission. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194494274",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 08:33:23",
@@ -3079,7 +4285,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Rise and Shine",
       "flickr_desc": "art002e012487 (April 7, 2026) - NASA’s Orion spacecraft is pictured here from one of the cameras mounted on its solar array wings. At the time this photo was taken at 8:33 a.m. ET, the Artemis II crew was in a sleep period ahead of beginning their seventh day into the mission. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193360877",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 08:58:03",
@@ -3094,7 +4306,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "NASA's Orion Spacecraft",
       "flickr_desc": "art002e012489 (April 7, 2026) - NASA’s Orion spacecraft is pictured here from one of the cameras mounted on its solar array wings. At the time this photo was taken at 8:58 a.m. ET, the Artemis II crew was in a sleep period ahead of beginning their seventh day into the mission. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194789840",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 09:03:43",
@@ -3109,7 +4327,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Orion in Flight",
       "flickr_desc": "art002e012495 (April 7, 2026) - NASA’s Orion spacecraft is pictured here from one of the cameras mounted on its solar array wings. At the time this photo was taken at 9:03 a.m. ET, the Artemis II crew was in a sleep period ahead of beginning their seventh day into the mission. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194789845",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 09:37:06",
@@ -3124,7 +4348,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis Lunar Science Team – Aaron Regberg",
       "flickr_desc": "Artemis lunar science team member, Aaron Regberg, works in the Science Mission Operations Room, where scientists analyzed imagery and audio recordings of lunar observations captured by the Artemis II astronauts during their lunar flyby on April 6, 2026. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199492819",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-07 09:40:25",
@@ -3139,7 +4369,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Guiding the Journey",
       "flickr_desc": "art002e012495 (April 7, 2026) - The engines on the Orion spacecraft’s service module are prominently featured in this image from flight day six of the Artemis II mission. Taken from a camera mounted on a solar array wing, the largest is the orbital maneuvering system engine, surrounded by eight smaller auxiliary thrusters. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194459003",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 09:40:26",
@@ -3154,7 +4390,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis Lunar Science Team",
       "flickr_desc": "Artemis lunar science team members, from left, Alexandra Constantinou, and David Hollibaugh-Baker, work in the Science Mission Operations Room at NASA’s Johnson Space Center in Houston. They are analyzing imagery and audio recordings of lunar observations captured by the Artemis II astronauts during their lunar flyby on April 6, 2026. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199492814",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-07 09:41:45",
@@ -3169,7 +4411,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "The Powerhouse of the Orion Spacecraft",
       "flickr_desc": "art002e012584 (April 7, 2026) - NASA’s Orion spacecraft pictured from one of the cameras mounted on its solar array wings. The service module is prominently featured in this image showing a portion of the orbital maneuvering system engine and three of eight auxiliary thrusters. Also pictured is one of the four solar array wings. Each of Orion’s four solar array wings are made of three panels that provide enough electricity to power two three-bedroom homes. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194517308",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 10:06:59",
@@ -3184,7 +4432,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis Lunar Science Team – Alexandra Constantinou",
       "flickr_desc": "Artemis lunar science team member, Alexandra Constantinou, works in the Science Mission Operations Room at NASA’s Johnson Space Center in Houston, where scientists analyzed imagery and audio recordings of lunar observations captured by the Artemis II astronauts during their lunar flyby on April 6, 2026. Credits: NASA/Helen Arase Vargas",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199243981",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-07 10:17:27",
@@ -3199,7 +4453,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Science Team in the Mission Operations Room",
       "flickr_desc": "Artemis lunar science team members, work in the Science Mission Operations Room at NASA’s Johnson Space Center in Houston, analyzing imagery and audio recordings of lunar observations captured by the Artemis II astronauts during their lunar flyby on April 6, 2026. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199649540",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-07 14:30:02",
@@ -3214,7 +4474,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery Director (NHQ202604070020)",
       "flickr_desc": "Lilian Villarreal, Artemis II landing and recovery director for Exploration Ground Systems at NASA's Kennedy Space Center, poses for a portrait onboard USS John P. Murtha, Tuesday, April 7, 2026, in the Pacific Ocean off the coast of California. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194365312",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 14:40:13",
@@ -3229,7 +4495,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Long Distance Call",
       "flickr_desc": "sc2026e021201 (April 7, 2026) - Members of the International Space Station Expedition 74 (left) and Artemis II (right) crews are seen at once on the screens inside the International Space Station flight control room in Mission Control at NASA's Johnson Space Center in Houston. The two crews connected in a 15-minute ship-to-ship call on April 7, 2026, while the Artemis II crew was on its way back from the Moon. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55195952067",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-07 14:42:13",
@@ -3244,7 +4516,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Long Distance Chat with Friends",
       "flickr_desc": "jsc2026e021206 (April 7, 2026) - Members of the International Space Station Expedition 74 (left) and Artemis II (right) crews are seen at once on the screens inside the International Space Station flight control room in Mission Control at NASA's Johnson Space Center in Houston. The two crews connected in a 15-minute ship-to-ship call on April 7, 2026, while the Artemis II crew was on its way back from the Moon. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55195952087",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-07 15:04:59",
@@ -3259,7 +4537,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Science Officers – Trevor Graff and Kelsey Young",
       "flickr_desc": "Artemis II science officers, Trevor Graff, background, and Kelsey Young are seen monitoring mission data in real-time from the Science console in the White Flight Control Room in Mission Control at NASA's Johnson Space Center in Houston. Science officers are the senior flight controllers responsible for lunar science and geology objectives during Artemis missions. Credits: NASA/Robert Markowitz",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199789389",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-07 15:44:31",
@@ -3275,7 +4559,13 @@ const PHOTO_DATA = {
       "title": "Waning Crescent Moon on the Return",
       "flickr_desc": "A slender crescent Moon photographed from the Orion spacecraft during the return coast to Earth. The sunlit portion reveals cratered terrain while the rest of the disk fades into darkness, a farewell view as the crew heads home.",
       "enabled": true,
-      "camera_id": "d5a"
+      "camera_id": "d5a",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55208397810",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 17:32:35",
@@ -3290,7 +4580,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Starstruck",
       "flickr_desc": "art002e012588 (April 7, 2026) - A stunning snapshot in time. The Artemis II crew captured this breathtaking photo of our galaxy, the Milky Way. The Milky Way’s elegant spiral structure is dominated by just two arms wrapping off the ends of a central bar of stars. Spanning more than 100,000 light-years, Earth is located along one of the galaxy’s spiral arms, about halfway from the center. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194523579",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 18:34:49",
@@ -3306,7 +4602,13 @@ const PHOTO_DATA = {
       "title": "Four Thumbs Up",
       "flickr_desc": "art002e013356 (April 7, 2026) – The Artemis II crew – (from left) Mission Specialist Christina Koch, Mission Specialist Jeremy Hansen, Pilot Victor Glover, and Commander Reid Wiseman – pause for a group photo inside the Orion spacecraft on their way home. Following a swing around the far side of the Moon on April 6, 2026, the crew exited the lunar sphere of influence (the point at which the Moon's gravity has a stronger pull on Orion than the Earth's) on April 7, and are headed back to Earth for a splashdown in the Pacific Ocean on April 10. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55195066435",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 18:35:09",
@@ -3322,7 +4624,13 @@ const PHOTO_DATA = {
       "title": "Artemis II Group Shoot",
       "flickr_desc": "art002e013361 (April 7, 2026) – The Artemis II crew – (clockwise from left) Mission Specialist Christina Koch, Mission Specialist Jeremy Hansen, Commander Reid Wiseman, and Pilot Victor Glover – pause for a group photo inside the Orion spacecraft on their way home. Following a swing around the far side of the Moon on April 6, 2026, the crew exited the lunar sphere of influence (the point at which the Moon's gravity has a stronger pull on Orion than the Earth's) on April 7, and are headed back to Earth for a splashdown in the Pacific Ocean on April 10. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194658516",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 18:35:25",
@@ -3338,7 +4646,13 @@ const PHOTO_DATA = {
       "title": "Artemis II Crew \"Rise-ing\" To the Occasion",
       "flickr_desc": "art002e013365 (April 7, 2026) – The Artemis II crew – (clockwise from left) Mission Specialist Christina Koch, Mission Specialist Jeremy Hansen, Commander Reid Wiseman, and Pilot Victor Glover – pause for a group photo with their zero gravity indicator &quot;Rise,&quot; inside the Orion spacecraft on their way home. Following a swing around the far side of the Moon on April 6, 2026, the crew exited the lunar sphere of influence (the point at which the Moon's gravity has a stronger pull on Orion than the Earth's) on April 7, and are headed back to Earth for a splashdown in the Pacific Ocean on April 10. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193772547",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 18:35:33",
@@ -3354,7 +4668,13 @@ const PHOTO_DATA = {
       "title": "Moon Joy",
       "flickr_desc": "art002e013367 (April 7, 2026) – The Artemis II crew – (clockwise from left) Mission Specialist Christina Koch, Mission Specialist Jeremy Hansen, Commander Reid Wiseman, and Pilot Victor Glover – take time out for a group hug inside the Orion spacecraft on their way home. Following a swing around the far side of the Moon on April 6, 2026, the crew exited the lunar sphere of influence (the point at which the Moon's gravity has a stronger pull on Orion than the Earth's) on April 7, and are headed back to Earth for a splashdown in the Pacific Ocean on April 10. The crew was selected in April 2023, and have been training together for their mission for the past three years. Credit: NASA",
       "enabled": true,
-      "camera_id": "d5b"
+      "camera_id": "d5b",
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55193772552",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 19:30:48",
@@ -3369,7 +4689,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery Preparations (NHQ202604070017)",
       "flickr_desc": "U.S. Navy MH-60 Seahawks from Helicopter Sea Combat Squadron (HSC) 23 depart USS John P. Murtha as they conduct air operations training as NASA, U.S. Navy, and U.S. Air Force teams prepare for the the return of the Artemis II crewmembers to Earth, Tuesday, April 7, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission is taking NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a 10-day journey around the Moon and back aboard their Orion spacecraft. Wiseman, Glover, Koch, and Hansen are scheduled to splash down off the coast of San Diego at approximately 5:07 p.m. PDT (8:07 p.m. EDT) on Friday, April 10. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55194733465",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-08 03:49:00",
@@ -3384,7 +4710,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Artemis II streaks through the stars — April 8",
       "flickr_desc": "Time-lapse of Artemis II spacecraft as seen from the ground, streaking through the star field. Captured by Scott Ferguson, PhD of Astronomy Live.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "4-8-26_7_49UT",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-08 12:00:00",
@@ -3399,7 +4731,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Lunar Crescent View",
       "flickr_desc": "art002e016354 (April 8, 2026) The Artemis II crew captures a thin lunar crescent as they travel back to Earth. Credit: NASA",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199431156",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-08 17:14:12",
@@ -3414,7 +4752,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery Preparations (NHQ202604080008)",
       "flickr_desc": "Lisa Mazzuca, mission manager for the Search and Rescue Office at NASA’s Goddard Space Flight Center, poses for a portrait on the bridge of USS John P. Murtha as teams prepare for the the return of the Artemis II crewmembers to Earth, Wednesday, April 8, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission is taking NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a 10-day journey around the Moon and back aboard their Orion spacecraft. Wiseman, Glover, Koch, and Hansen are scheduled to splash down off the coast of San Diego at approximately 5:07 p.m. PDT (8:07 p.m. EDT) on Friday, April 10. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55197019103",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-08 20:00:00",
@@ -3429,7 +4773,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Flight Day 8 Evening Vibes",
       "flickr_desc": "Flight Day 8 evening vibes. This day was so fun and productive because we had gotten our sea legs and were executing like a well-oiled machine. Sound on! — via Instagram",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ig-fd8-evening-vibes",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-08 21:30:00",
@@ -3444,7 +4794,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Flight Day 8 Press Conference",
       "flickr_desc": "Flight Day 8 evening, before bed — the Artemis II crew during a press conference on their return journey to Earth. — via Instagram",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ig-fd8-press-conference",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-08 21:47:48",
@@ -3459,7 +4815,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Crew Video Call from Orion",
       "flickr_desc": "The four Artemis II crew members wave and smile during a video call from inside the Orion spacecraft, displayed on a large screen at an Artemis event. American and Canadian flags and an America 250 banner float above them in microgravity.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55207851286",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-09 11:34:59",
@@ -3474,7 +4836,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Assistant NASA Recovery Director (NHQ202604090001)",
       "flickr_desc": "Paul Sierpinski, assistant NASA Recovery Director, poses for a portrait onboard USS John P. Murtha, Thursday, April 9, 2026, in the Pacific Ocean off the coast of California. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55197162528",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-09 13:12:59",
@@ -3489,7 +4857,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery Preparations (NHQ202604090003)",
       "flickr_desc": "Support buoys are seen onboard USS John P. Murtha ahead of the return of the Artemis II crewmembers to Earth, Thursday, April 9, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission is taking NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a 10-day journey around the Moon and back aboard their Orion spacecraft. Wiseman, Glover, Koch, and Hansen are scheduled to splash down off the coast of San Diego at approximately 5:07 p.m. PDT (8:07 p.m. EDT) on Friday, April 10. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55197806006",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-09 13:45:35",
@@ -3504,7 +4878,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery Preparations (NHQ202604090006)",
       "flickr_desc": "View of the USS John P. Murtha flight deck is seen from the air boss tower ahead of the return of the Artemis II crewmembers to Earth, Thursday, April 9, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission is taking NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a 10-day journey around the Moon and back aboard their Orion spacecraft. Wiseman, Glover, Koch, and Hansen are scheduled to splash down off the coast of San Diego at approximately 5:07 p.m. PDT (8:07 p.m. EDT) on Friday, April 10. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55196918247",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-09 16:06:34",
@@ -3519,7 +4899,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery Preparations (NHQ202604090010)",
       "flickr_desc": "A support boat is seen along side USS John P. Murtha as teams prepare for the return of the Artemis II crewmembers to Earth, Thursday, April 9, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission is taking NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a 10-day journey around the Moon and back aboard their Orion spacecraft. Wiseman, Glover, Koch, and Hansen are scheduled to splash down off the coast of San Diego at approximately 5:07 p.m. PDT (8:07 p.m. EDT) on Friday, April 10. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55196921082",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 12:37",
@@ -3532,7 +4918,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": false,
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55206199989",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 15:36:40",
@@ -3547,7 +4939,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery Preparations (NHQ202604100066)",
       "flickr_desc": "U.S. Navy MH-60 Seahawks from Helicopter Sea Combat Squadron (HSC) 23 are seen on the flight deck of USS John P. Murtha as NASA, U.S. Navy, and U.S. Air Force teams prepare for the the return of the Artemis II crewmembers to Earth, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission is taking NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly 10-day journey around the Moon and back aboard their Orion spacecraft. Wiseman, Glover, Koch, and Hansen are scheduled to splash down off the coast of San Diego at approximately 5:07 p.m. PDT (8:07 p.m. EDT) on Friday, April 10. Photo Credit: (NASA/Bill Ingalls/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201073550",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 16:05:51",
@@ -3562,7 +4960,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery Preparations (NHQ202604100001)",
       "flickr_desc": "A U.S. Navy CMV-22 Osprey is seen as it approaches the flight deck of USS John P. Murtha with NASA Administrator Jared Isaacman, U.S. Navy Rear Adm. Brent DeVore, Commander, Expeditionary Strike Group Three, and U.S. Air Force Maj. Gen. Michael A. Valle, Deputy Commander, First Air Force, as NASA and U.S. military teams prepare for the the return of the Artemis II crewmembers to Earth, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission is taking NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a 10-day journey around the Moon and back aboard their Orion spacecraft. Wiseman, Glover, Koch, and Hansen are scheduled to splash down off the coast of San Diego at approximately 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199318256",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 16:11:05",
@@ -3577,7 +4981,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery Preparations",
       "flickr_desc": "NASA Administrator Jared Isaacman, left, is greeted by Capt. Erik Kenny, commanding officer, USS John P. Murtha (LPD, after a U.S. Navy CMV-22 Osprey landed on the flight deck of USS John P. Murtha with U.S. Navy Rear Adm. Brent DeVore, Commander, Expeditionary Strike Group Three, Michael Altenhofen, senior advisor to the NASA Administrator, and U.S. Air Force Maj. Gen. Michael A. Valle, Deputy Commander, First Air Force, as NASA and U.S. military teams prepare for the the return of the Artemis II crew members to Earth, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission is taking NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a 10-day journey around the Moon and back aboard their Orion spacecraft. Wiseman, Glover, Koch, and Hansen are scheduled to splash down off the coast of San Diego at approximately 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199324306",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 16:11:33",
@@ -3592,7 +5002,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery Preparations",
       "flickr_desc": "NASA Administrator Jared Isaacman, center, is greeted by Capt. Erik Kenny, commanding officer, USS John P. Murtha (LPD), right, after Isaacman arrived on a U.S. Navy CMV-22 Osprey with Michael Altenhofen, senior advisor to the NASA Administrator, U.S. Navy Rear Adm. Brent DeVore, Commander, Expeditionary Strike Group Three, Michael Altenhofen, senior advisor to the NASA Administrator, and U.S. Air Force Maj. Gen. Michael A. Valle, Deputy Commander, First Air Force, as NASA and U.S. military teams prepare for the the return of the Artemis II crew members to Earth, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission is taking NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a 10-day journey around the Moon and back aboard their Orion spacecraft. Wiseman, Glover, Koch, and Hansen are scheduled to splash down off the coast of San Diego at approximately 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199507598",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 17:52:06",
@@ -3607,7 +5023,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "Small boats are seen alongside USS John P. Murtha as teams prepare to recover \\\\mission\\\\ crewmembers \\\\crew\\\\ and NASA’s Orion spacecraft in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s \\\\mission\\\\ mission took \\\\crewln\\\\ on a 10-day journey around the Moon and back to Earth. The quartet is scheduled to splash down off the coast of San Diego at approximately 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199520466",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 18:16:47",
@@ -3622,7 +5044,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100012)",
       "flickr_desc": "U.S. Navy divers prepare to deploy in small boats from the well deck of USS John P. Murtha to recover Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist and NASA’s Orion spacecraft in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back to Earth. Following a splashdown at , NASA and U.S. military teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55198634897",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 18:17:00",
@@ -3637,7 +5065,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "U.S. Navy divers deploy in small boats from the well deck of USS John P. Murtha to recover Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist and NASA’s Orion spacecraft in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back to Earth. Following a splashdown at , NASA and U.S. military teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199526571",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 18:17:41",
@@ -3652,7 +5086,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100014)",
       "flickr_desc": "U.S. Navy divers deploy in small boats from the well deck of USS John P. Murtha to recover Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist and NASA’s Orion spacecraft in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a 10-day journey around the Moon and back to Earth. Following a splashdown at , NASA and U.S. military teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199775909",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 19:04:07",
@@ -3667,7 +5107,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "A U.S. Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 departs from the flight deck of USS John P. Murtha as NASA and U.S. military teams deploy in preparation for the the return of the Artemis II crewmembers to Earth, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission is taking NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a 10-day journey around the Moon and back aboard their Orion spacecraft. Wiseman, Glover, Koch, and Hansen are scheduled to splash down off the coast of San Diego at approximately 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199709323",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 19:11:46",
@@ -3682,7 +5128,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA Administrator Jared Isaacman launches a weather balloon for the 45th Weather Squadron from USS John P. Murtha as NASA and U.S. military teams prepare for the return of the Artemis II crewmembers to Earth, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission is taking NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a 10-day journey around the Moon and back aboard their Orion spacecraft. Wiseman, Glover, Koch, and Hansen are scheduled to splash down off the coast of San Diego at approximately 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199558901",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:04:30",
@@ -3697,7 +5149,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA’s Orion spacecraft with Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist aboard is seen under drogue parachutes as it lands in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200049934",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:04:32",
@@ -3712,7 +5170,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA’s Orion spacecraft with Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist aboard is seen as the main parachutes begin to deploy as it lands in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55198907367",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:04:34",
@@ -3727,7 +5191,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA’s Orion spacecraft with Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist aboard is seen as the main parachutes begin to deploy as it lands in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200207020",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:04:36",
@@ -3742,7 +5212,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA’s Orion spacecraft with Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist aboard is seen as the main parachutes begin to deploy as it lands in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200207390",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:04:56",
@@ -3757,7 +5233,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA’s Orion spacecraft with Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist aboard is seen under parachutes as it lands in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199953168",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:06:20",
@@ -3772,7 +5254,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Splashdown",
       "flickr_desc": "jsc2026e022262 (April 10, 2026) - NASA's Orion spacecraft carrying Artemis II Commander Reid Wiseman, Pilot Victor Glover, and Mission Specialist Christina Koch from NASA, along with Mission Specialist Jeremy Hansen from the CSA (Canadian Space Agency), splashes down in the Pacific Ocean near San Diego, California, at 5:07 p.m. PDT, (8:07 p.m. EDT) on Friday, April 10, 2026. The Artemis II test flight launched on Wednesday, April 1, from NASA’s Kennedy Space Center in Florida to begin its 10-day journey around the Moon for scientific discovery, economic benefits, and to build on our foundation for the first crewed missions to Mars. NASA’s Landing and Recovery team and the U.S. military are coordinating efforts to extract the Artemis II crew from the Orion spacecraft. Credit: NASA/Josh Valcarcel",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201553518",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:06:39",
@@ -3787,7 +5275,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Flight Control Team During Splashdown",
       "flickr_desc": "jsc2026e022251(April 10, 2026) - Artemis II Flight Control Team pictured at consoles within the White Flight Control Room in the Mission Control Center at NASA’s Johnson Space Center for the splashdown and recovery of the Artemis II crew as it landed in the Pacific Ocean off the coast of California, Friday, April 10, 2026 at 7:07 p.m. CDT. NASA’s Artemis II mission took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen on a nearly 10-day journey around the Moon and back to Earth. Credit: NASA/Robert Markowitz",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200077344",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-10 20:06:56",
@@ -3802,7 +5296,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Splashdown",
       "flickr_desc": "jsc2026e022263 (April 10, 2026) - NASA's Orion spacecraft carrying Artemis II Commander Reid Wiseman, Pilot Victor Glover, and Mission Specialist Christina Koch from NASA, along with Mission Specialist Jeremy Hansen from the CSA (Canadian Space Agency), splashes down in the Pacific Ocean near San Diego, California, at 5:07 p.m. PDT, (8:07 p.m. EDT) on Friday, April 10, 2026. The Artemis II test flight launched on Wednesday, April 1, from NASA’s Kennedy Space Center in Florida to begin its 10-day journey around the Moon for scientific discovery, economic benefits, and to build on our foundation for the first crewed missions to Mars. NASA’s Landing and Recovery team and the U.S. military are coordinating efforts to extract the Artemis II crew from the Orion spacecraft. Credit: NASA/Josh Valcarcel",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201805415",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:07:00",
@@ -3815,7 +5315,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": false,
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "jsc2026e022251",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-10 20:07:17",
@@ -3830,7 +5336,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA’s Orion spacecraft with Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist aboard is seen under parachutes as it lands in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 8:07 p.m. EDT, NASA, U.S. Navy, and U.S. Air Force teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199878864",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:07:18",
@@ -3843,7 +5355,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": true,
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "nhq202604100018",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:07:24",
@@ -3858,7 +5376,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA’s Orion spacecraft with Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist aboard is seen as it lands in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 8:07 p.m. EDT, NASA, U.S. Navy, and U.S. Air Force teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199878669",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:07:26",
@@ -3873,7 +5397,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Splashdown",
       "flickr_desc": "jsc2026e022246 (April 10, 2026) - NASA's Orion spacecraft carrying Artemis II Commander Reid Wiseman, Pilot Victor Glover, and Mission Specialist Christina Koch from NASA, along with Mission Specialist Jeremy Hansen from the CSA (Canadian Space Agency), splashes down in the Pacific Ocean near San Diego, California, at 5:07 p.m. PDT, (8:07 p.m. EDT) on Friday, April 10, 2026. The Artemis II test flight launched on Wednesday, April 1, from NASA’s Kennedy Space Center in Florida to begin its 10-day journey around the Moon for scientific discovery, economic benefits, and to build on our foundation for the first crewed missions to Mars. NASA’s Landing and Recovery team and the U.S. military are coordinating efforts to extract the Artemis II crew from the Orion spacecraft. Credit: NASA/Josh Valcarcel",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199856343",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:07:26",
@@ -3886,7 +5416,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": true,
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "dsc-3398",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:07:29",
@@ -3900,7 +5436,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Orion Parachutes Toward the Pacific",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9609103",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:07:29",
@@ -3915,7 +5457,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Splashdown",
       "flickr_desc": "jsc2026e022247 (April 10, 2026) - NASA's Orion spacecraft carrying Artemis II Commander Reid Wiseman, Pilot Victor Glover, and Mission Specialist Christina Koch from NASA, along with Mission Specialist Jeremy Hansen from the CSA (Canadian Space Agency), splashes down in the Pacific Ocean near San Diego, California, at 5:07 p.m. PDT, (8:07 p.m. EDT) on Friday, April 10, 2026. The Artemis II test flight launched on Wednesday, April 1, from NASA’s Kennedy Space Center in Florida to begin its 10-day journey around the Moon for scientific discovery, economic benefits, and to build on our foundation for the first crewed missions to Mars. NASA’s Landing and Recovery team and the U.S. military are coordinating efforts to extract the Artemis II crew from the Orion spacecraft. Credit: NASA/Josh Valcarcel",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199856318",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:07:29",
@@ -3928,7 +5476,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": true,
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "dsc-3427",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:07:36",
@@ -3943,7 +5497,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA’s Orion spacecraft with Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist aboard is seen as it lands in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 8:07p.m. EDT, NASA, U.S. Navy, and U.S. Air Force teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199685771",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:07:43",
@@ -3958,7 +5518,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA’s Orion spacecraft with Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist aboard is seen as it lands in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 8:07p.m. EDT, NASA, U.S. Navy, and U.S. Air Force teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200091055",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:07:47",
@@ -3973,7 +5539,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA’s Orion spacecraft with Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist aboard is seen as it lands in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 8:07p.m. EDT, NASA, U.S. Navy, and U.S. Air Force teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199935584",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:15:00",
@@ -3986,7 +5558,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": true,
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "JB5_0746",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:17:00",
@@ -3999,7 +5577,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": true,
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "JB5_0814",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:19:00",
@@ -4012,7 +5596,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": true,
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "JB5_0855",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:22:02",
@@ -4027,7 +5617,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "A U.S. Navy MH-60 Seahawks from Helicopter Sea Combat Squadron (HSC) 23 flies overhead as small boats approach NASA’s Orion spacecraft with Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist aboard is seen after landing as recovery teams as NASA’s Landing and Recovery team, along with U.S. Navy personnel in small boats begin to approach the spacecraft in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA and U.S. military teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200100035",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:26:25",
@@ -4042,7 +5638,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "Three U.S. Navy MH-60 Seahawks from Helicopter Sea Combat Squadron (HSC) 23 flies overhead as small boats approach NASA’s Orion spacecraft with Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist aboard is seen after landing as recovery teams as NASA’s Landing and Recovery team, along with U.S. Navy personnel in small boats begin to approach the spacecraft in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA and U.S. military teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55198801842",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:28:43",
@@ -4057,7 +5659,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Splashdown",
       "flickr_desc": "jsc2026e022266 (April 10, 2026) - NASA's Orion spacecraft carrying Artemis II Commander Reid Wiseman, Pilot Victor Glover, and Mission Specialist Christina Koch from NASA, along with Mission Specialist Jeremy Hansen from the CSA (Canadian Space Agency), splashes down in the Pacific Ocean near San Diego, California, at 5:07 p.m. PDT, (8:07 p.m. EDT) on Friday, April 10, 2026. The Artemis II test flight launched on Wednesday, April 1, from NASA’s Kennedy Space Center in Florida to begin its 10-day journey around the Moon for scientific discovery, economic benefits, and to build on our foundation for the first crewed missions to Mars. NASA’s Landing and Recovery team and the U.S. military are coordinating efforts to extract the Artemis II crew from the Orion spacecraft. Credit: NASA/James Blair",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201813860",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:29:32",
@@ -4072,7 +5680,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "Two U.S. Navy MH-60 Seahawks from Helicopter Sea Combat Squadron (HSC) 23 flies overhead as small boats approach NASA’s Orion spacecraft with Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist aboard is seen after landing as recovery teams as NASA’s Landing and Recovery team, along with U.S. Navy personnel in small boats begin to approach the spacecraft in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA and U.S. military teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199695466",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:37:18",
@@ -4087,7 +5701,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "A U.S. Navy MH-60 Seahawks from Helicopter Sea Combat Squadron (HSC) 23 flies overhead as small boats approach NASA’s Orion spacecraft with Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist aboard is seen after landing as recovery teams as NASA’s Landing and Recovery team, along with U.S. Navy personnel in small boats begin to approach the spacecraft in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA and U.S. military teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199695136",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:40:47",
@@ -4101,7 +5721,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Navy Divers Prep Hazmat Sweep",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9609114",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:42:54",
@@ -4115,7 +5741,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Hazardous Material Detection Sweep",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9609116",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:50:10",
@@ -4128,7 +5760,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Navy Divers Approach Orion in the Pacific",
       "flickr_desc": "U.S. Navy divers in a rigid-hull inflatable boat approach the Orion spacecraft floating in the Pacific Ocean with its five flotation bags deployed after splashdown.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260411-KED01-0249",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:50:11",
@@ -4143,7 +5781,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Welcome Aboard Integrity",
       "flickr_desc": "Jesse, Steve, Laddy, and Vlad… such an incredible feeling to welcome you aboard Integrity after your journey around the Moon. The recovery team opens the Orion capsule hatch aboard USS John P. Murtha. — via Instagram",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ig-welcome-aboard",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:56:18",
@@ -4156,7 +5800,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Navy Divers Work at the Orion Hatch",
       "flickr_desc": "U.S. Navy divers work at the hatch of the Orion spacecraft in the Pacific Ocean, with inflatable boats alongside and flotation bags visible above.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260411-KED01-0267",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:57:31",
@@ -4169,7 +5819,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Close-Up of Orion's Heat Shield and Hatch",
       "flickr_desc": "A close-up view of the Orion spacecraft's charred heat shield tiles and open hatch, with a yellow hazmat covering being positioned by a Navy diver during post-splashdown operations.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260411-KED01-0285",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:58:05",
@@ -4182,7 +5838,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Wide View of Orion Recovery Operations",
       "flickr_desc": "A wide view of the Orion spacecraft in the Pacific Ocean surrounded by Navy rigid-hull inflatable boats and divers, with flotation bags keeping the capsule upright.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260411-KED01-0287",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:58:13",
@@ -4196,7 +5858,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Divers Approach the Crew Module",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9609122",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:58:43",
@@ -4211,7 +5879,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Coming Home",
       "flickr_desc": "The moments just after the capsule is opened — the Artemis II crew exits the Orion spacecraft aboard USS John P. Murtha following splashdown. — via Instagram",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ig-capsule-egress",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 20:58:50",
@@ -4225,7 +5899,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Divers Enter the Crew Module",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9609124",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 21:13:25",
@@ -4240,7 +5920,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA’s Orion spacecraft is seen as recovery teams work to secure the spacecraft ahead of transferring Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist to USS John P. Murtha in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT(8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55198811582",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 21:14:04",
@@ -4255,7 +5941,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA’s Orion spacecraft is seen as recovery teams work to secure the spacecraft ahead of transferring Artemis II crewmembers NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist to USS John P. Murtha in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission took Wiseman, Glover, Koch, and Hansen on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT(8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the crewmembers and Orion spacecraft aboard USS John P. Murtha. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199854793",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 21:16:33",
@@ -4269,7 +5961,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Splashdown Near USS John P. Murtha",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608786",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 21:31:04",
@@ -4282,7 +5980,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Crew Extraction on the Front Porch",
       "flickr_desc": "Navy divers assist an Artemis II crew member in an orange suit on the front porch life raft next to the Orion spacecraft during crew extraction operations in the Pacific Ocean.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260411-KED01-0384",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 21:33:00",
@@ -4295,7 +5999,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Divers Secure Orion After Crew Extraction",
       "flickr_desc": "Navy divers work alongside the Orion capsule and its flotation bags after the crew has been extracted, with inflatable boats surrounding the spacecraft.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260411-KED01-0425",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 21:37:02",
@@ -4309,7 +6019,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Wiseman Exits Onto the Front Porch",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9609077",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 21:37:20",
@@ -4323,7 +6039,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Commander Wiseman on the Front Porch",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9609126",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 21:40:58",
@@ -4337,7 +6059,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "All Four Crew on the Front Porch",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9609128",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 21:52:36",
@@ -4352,7 +6080,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "A Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 is seen as it lifts NASA astronaut Victor Glover, Artemis II pilot as teams work to bring the crewmembers aboard USS John P. Murtha, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took Glover, NASA astronauts Reid Wiseman, commander; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the crewmembers and Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200008149",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 21:54:13",
@@ -4365,7 +6099,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Astronaut Hoisted to the Helicopter",
       "flickr_desc": "A U.S. Navy MH-60S Seahawk helicopter hoists an Artemis II crew member in their orange suit from the ocean surface during recovery operations at sunset.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260411-KED01-0652",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 21:55:29",
@@ -4379,7 +6119,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Hoisted to the Seahawk",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9609139",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 21:59:00",
@@ -4394,7 +6140,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100211)",
       "flickr_desc": "A Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 with NASA astronaut Reid Wiseman, Artemis II commander and CSA (Canadian Space Agency) astronaut Jeremy Hansen, Artemis II mission specialist, approaches the flight deck of USS John P. Murtha, Friday, April 10, 2026, in the Pacific Ocean off the coast of California as teams work to bring the crewmembers aboard. NASA’s Artemis II mission took Wiseman, Hansen, and NASA astronauts Victor Glover, pilot; and Christina Koch, mission specialist; on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the crewmembers and Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55198865542",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:00:07",
@@ -4408,7 +6160,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Hansen Celebrates in the Helicopter",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608699",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:00:41",
@@ -4422,7 +6180,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Wiseman and Hansen After Extraction",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608700",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:01:00",
@@ -4437,7 +6201,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100046)",
       "flickr_desc": "NASA astronaut Christina Koch, Artemis II mission specialist is assisted off the flight deck after arriving aboard USS John P. Murtha after she and fellow crewmates NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a 10-day journey around the Moon and back to Earth. Following a splashdown at , NASA and U.S. military teams are working to bring the crewmembers and Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200111364",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:01:20",
@@ -4452,7 +6222,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100047)",
       "flickr_desc": "NASA astronaut Christina Koch, Artemis II mission specialist is assisted off the flight deck after arriving aboard USS John P. Murtha after she and fellow crewmates NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a 10-day journey around the Moon and back to Earth. Following a splashdown at , NASA and U.S. military teams are working to bring the crewmembers and Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199863796",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:01:40",
@@ -4467,7 +6243,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100048)",
       "flickr_desc": "NASA astronaut Christina Koch, Artemis II mission specialist is assisted off the flight deck after arriving aboard USS John P. Murtha after she and fellow crewmates NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a 10-day journey around the Moon and back to Earth. Following a splashdown at , NASA and U.S. military teams are working to bring the crewmembers and Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200013283",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:02:00",
@@ -4482,7 +6264,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100051)",
       "flickr_desc": "NASA astronaut Victor Glover, Artemis II pilot shakes hands with Scott Tingle, Chief of the Astronaut Office as he is assisted from a Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after he and fellow crewmates NASA Astronauts Reid Wiseman, Christina Koch, and CSA (Canadian Space Agency) astronaut Jeremy Hansen, Artemis II mission specialist were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199868461",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:02:20",
@@ -4497,7 +6285,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100052)",
       "flickr_desc": "NASA astronaut Victor Glover, Artemis II pilot is assisted off the flight deck after arriving aboard USS John P. Murtha after he and fellow crewmates NASA astronauts Reid Wiseman, commander; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a 10-day journey around the Moon and back to Earth. Following a splashdown at , NASA and U.S. military teams are working to bring the crewmembers and Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199869846",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:02:40",
@@ -4512,7 +6306,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100053)",
       "flickr_desc": "NASA astronaut Victor Glover, Artemis II pilot is assisted off the flight deck after arriving aboard USS John P. Murtha after he and fellow crewmates NASA astronauts Reid Wiseman, commander; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a 10-day journey around the Moon and back to Earth. Following a splashdown at , NASA and U.S. military teams are working to bring the crewmembers and Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200119619",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:03:00",
@@ -4527,7 +6327,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100054)",
       "flickr_desc": "NASA astronaut Victor Glover, Artemis II pilot is assisted off the flight deck after arriving aboard USS John P. Murtha after he and fellow crewmates NASA astronauts Reid Wiseman, commander; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a 10-day journey around the Moon and back to Earth. Following a splashdown at , NASA and U.S. military teams are working to bring the crewmembers and Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199872986",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:03:20",
@@ -4542,7 +6348,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100055)",
       "flickr_desc": "NASA astronaut Reid Wiseman, Artemis II commander is seen sitting in a Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after he and fellow crewmates NASA Astronauts Victor Glover, Christina Koch, and CSA (Canadian Space Agency) astronaut Jeremy Hansen, were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200122669",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:03:40",
@@ -4557,7 +6369,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100056)",
       "flickr_desc": "NASA astronaut Reid Wiseman, Artemis II commander is assisted off the flight deck after arriving aboard USS John P. Murtha after he and fellow crewmates NASA Astronauts Victor Glover, Christina Koch, and CSA (Canadian Space Agency) astronaut Jeremy Hansen, were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a 10-day journey around the Moon and back to Earth. Following a splashdown at , NASA and U.S. military teams are working to bring the crewmembers and Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55198981287",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:04:00",
@@ -4572,7 +6390,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100058)",
       "flickr_desc": "NASA astronaut Reid Wiseman, Artemis II commander is assisted off the flight deck after arriving aboard USS John P. Murtha after he and fellow crewmates NASA Astronauts Victor Glover, Christina Koch, and CSA (Canadian Space Agency) astronaut Jeremy Hansen, were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a 10-day journey around the Moon and back to Earth. Following a splashdown at , NASA and U.S. military teams are working to bring the crewmembers and Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55198982147",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:04:14",
@@ -4586,7 +6410,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Wiseman and Hansen on the Flight Deck",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608622",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:04:59",
@@ -4600,7 +6430,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Wiseman and Hansen – Portrait",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608623",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:05:57",
@@ -4615,7 +6451,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA astronaut Reid Wiseman, Artemis II commander, left, and CSA (Canadian Space Agency) astronaut Jeremy Hansen, Artemis II mission specialist, are seen sitting on a Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after they and fellow crewmates NASA astronaut Christina Koch, Artemis II mission specialist, and NASA astronaut Victor Glover, Artemis II pilot, were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55198951957",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:06:00",
@@ -4629,7 +6471,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Glover and Koch in the Seahawk",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608624",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:06:02",
@@ -4644,7 +6492,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA astronaut Victor Glover, Artemis II pilot, left, and NASA astronaut Christina Koch, Artemis II mission specialist are seen sitting on a Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after they and fellow crewmates CSA (Canadian Space Agency) astronaut Jeremy Hansen, Artemis II mission specialist, and NASA astronaut Reid Wiseman, Artemis II commander, were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55198952237",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:06:08",
@@ -4659,7 +6513,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA astronaut Reid Wiseman, Artemis II commander, gives NASA Flight Surgeon Richard Scheuring a hug next to a Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after he and fellow crewmates NASA Astronauts Victor Glover, Christina Koch, and CSA (Canadian Space Agency) astronaut Jeremy Hansen, were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199996653",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:06:21",
@@ -4673,7 +6533,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Glover and Koch After Landing",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608625",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:06:30",
@@ -4688,7 +6554,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA astronaut Reid Wiseman, Artemis II commander, left, and CSA (Canadian Space Agency) astronaut Jeremy Hansen, Artemis II mission specialist, talk with NASA Flight Surgeon Richard Scheuring at their Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after they and fellow crewmates NASA Astronauts Victor Glover, and Christina Koch were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200096939",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:06:34",
@@ -4703,7 +6575,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA astronaut Reid Wiseman, Artemis II commander is seen sitting in a Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after he and fellow crewmates NASA Astronauts Victor Glover, Christina Koch, and CSA (Canadian Space Agency) astronaut Jeremy Hansen, were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199997948",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:06:37",
@@ -4718,7 +6596,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "CSA (Canadian Space Agency) astronaut Jeremy Hansen, Artemis II mission specialist is seen sitting in a Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after he and fellow crewmates NASA Astronauts Reid Wiseman, Victor Glover, and Christina Koch, were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199998298",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:06:51",
@@ -4733,7 +6617,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA astronaut Victor Glover, Artemis II pilot, left, and NASA astronaut Christina Koch, Artemis II mission specialist are seen sitting on a Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after they and fellow crewmates CSA (Canadian Space Agency) astronaut Jeremy Hansen, Artemis II mission specialist, and NASA astronaut Reid Wiseman, Artemis II commander, were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199999093",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:06:52",
@@ -4748,7 +6638,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA astronaut Victor Glover, Artemis II pilot, left, and NASA astronaut Christina Koch, Artemis II mission specialist are seen sitting on a Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after they and fellow crewmates CSA (Canadian Space Agency) astronaut Jeremy Hansen, Artemis II mission specialist, and NASA astronaut Reid Wiseman, Artemis II commander, were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200099409",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:07:20",
@@ -4762,7 +6658,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Koch in the Seahawk",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608626",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:07:21",
@@ -4776,7 +6678,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Christina Koch – Portrait",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608627",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:07:29",
@@ -4791,7 +6699,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA astronaut Victor Glover, Artemis II pilot, left, and CSA (Canadian Space Agency) astronaut Jeremy Hansen, Artemis II mission specialist, talk with NASA Administrator Jared Isaacman at their Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after they and fellow crewmates NASA Astronauts Victor Glover, and Christina Koch were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200000228",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:07:29",
@@ -4804,7 +6718,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Hansen and Wiseman Arrive on the Flight Deck",
       "flickr_desc": "Astronauts Jeremy Hansen and Reid Wiseman in their orange suits exit a Navy Seahawk helicopter on the flight deck of USS John P. Murtha, greeted by Jared Isaacman and recovery team members at sunset.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "NHQ202604100032",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:08:01",
@@ -4818,7 +6738,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Glover Salutes the Sailors",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608701",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:08:09",
@@ -4833,7 +6759,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA astronaut Reid Wiseman, Artemis II commander is seen sitting in a Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after he and fellow crewmates NASA Astronauts Victor Glover, Christina Koch, and CSA (Canadian Space Agency) astronaut Jeremy Hansen, were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200255400",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:08:11",
@@ -4848,7 +6780,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "CSA (Canadian Space Agency) astronaut Jeremy Hansen, Artemis II mission specialist is seen sitting in a Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after he and fellow crewmates NASA Astronauts Reid Wiseman, Victor Glover, and Christina Koch, were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200256115",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:08:13",
@@ -4862,7 +6800,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Glover Claps for the Ship’s Crew",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608702",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:08:16",
@@ -4876,7 +6820,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Glover and Koch Receive Ship Hats",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608628",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:08:19",
@@ -4891,7 +6841,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA astronaut Reid Wiseman, Artemis II commander, left, and CSA (Canadian Space Agency) astronaut Jeremy Hansen, Artemis II mission specialist, talk with NASA Flight Surgeon Richard Scheuring at their Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after they and fellow crewmates NASA Astronauts Victor Glover, and Christina Koch were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200101349",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:08:27",
@@ -4905,7 +6861,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Putting On Ship Hats",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608629",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:08:38",
@@ -4920,7 +6882,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA astronaut Victor Glover, Artemis II pilot, left, and NASA astronaut Christina Koch, Artemis II mission specialist, talk with NASA Administrator Jared Isaacman at their Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after they and fellow crewmates NASA Astronauts Victor Glover, and Christina Koch were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200002168",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:08:47",
@@ -4935,7 +6903,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA astronaut Victor Glover, Artemis II pilot, left, and NASA astronaut Christina Koch, Artemis II mission specialist, talk with NASA Administrator Jared Isaacman at their Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after they and fellow crewmates NASA Astronauts Victor Glover, and Christina Koch were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199853946",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:08:47",
@@ -4948,7 +6922,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Glover and Koch Exit the Helicopter",
       "flickr_desc": "NASA astronauts Victor Glover and Christina Koch sit in the doorway of a Navy Seahawk helicopter on the flight deck of USS John P. Murtha, talking with recovery team members.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "NHQ202604100037",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:08:55",
@@ -4963,7 +6943,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA astronaut Victor Glover, Artemis II pilot is seen sitting in a Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after he and fellow crewmates NASA Astronauts Reid Wiseman, Christina Koch, and CSA (Canadian Space Agency) astronaut Jeremy Hansen, Artemis II mission specialist were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200103109",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:09:27",
@@ -4978,7 +6964,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "CSA (Canadian Space Agency) astronaut Jeremy Hansen, Artemis II mission specialist is assisted off the flight deck after arriving aboard USS John P. Murtha after he and fellow crewmates NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; and Christina Koch, mission specialist were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199854926",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:09:35",
@@ -4993,7 +6985,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "CSA (Canadian Space Agency) astronaut Jeremy Hansen, Artemis II mission specialist is assisted off the flight deck after arriving aboard USS John P. Murtha with fellow crewmates NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; and Christina Koch, mission specialist were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55198960402",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:09:43",
@@ -5007,7 +7005,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Wiseman Talks to NASA Personnel",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608630",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:09:51",
@@ -5022,7 +7026,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA astronaut Victor Glover, Artemis II pilot, left, and NASA astronaut Christina Koch, Artemis II mission specialist are seen sitting on a Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after they and fellow crewmates CSA (Canadian Space Agency) astronaut Jeremy Hansen, Artemis II mission specialist, and NASA astronaut Reid Wiseman, Artemis II commander, were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200004673",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:10:00",
@@ -5037,7 +7047,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery",
       "flickr_desc": "NASA astronaut Victor Glover, Artemis II pilot, left, and NASA astronaut Christina Koch, Artemis II mission specialist are seen sitting on a Navy MH-60 Seahawk from Helicopter Sea Combat Squadron (HSC) 23 on the flight deck of USS John P. Murtha after they and fellow crewmates CSA (Canadian Space Agency) astronaut Jeremy Hansen, Artemis II mission specialist, and NASA astronaut Reid Wiseman, Artemis II commander, were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a nearly 10-day journey around the Moon and back to Earth. Following a splashdown at 5:07 p.m. PDT (8:07 p.m. EDT), NASA, U.S. Navy, and U.S. Air Force teams are working to bring the Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199857746",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:10:00",
@@ -5050,7 +7066,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Glover and Koch Laugh on the Flight Deck",
       "flickr_desc": "NASA astronauts Victor Glover and Christina Koch laugh next to the Navy helicopter on the flight deck of USS John P. Murtha, wearing NASA caps over their orange suits.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "NHQ202604100043",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:10:16",
@@ -5063,7 +7085,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Glover and Koch With the Ship's Captain",
       "flickr_desc": "NASA astronauts Victor Glover and Christina Koch chat with recovery officials next to the helicopter on the flight deck of USS John P. Murtha. Koch wears a ship's cap reading 'USS John P. Murtha - Astronaut Recovery - Artemis II'.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "NHQ202604100044",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:10:34",
@@ -5077,7 +7105,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Wiseman and Hansen Don Navy Ballcaps",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608682",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:10:54",
@@ -5091,7 +7125,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Glover Celebrates on the Flight Deck",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608631",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:10:55",
@@ -5105,7 +7145,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Glover Points to Crew Members",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608632",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:11:02",
@@ -5119,7 +7165,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Glover Claps with the Crew",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608633",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:12:27",
@@ -5133,7 +7185,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Glover and Koch Embrace Scott Tingle",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608687",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:12:51",
@@ -5146,7 +7204,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Reid Wiseman Walks the Flight Deck",
       "flickr_desc": "NASA astronaut Reid Wiseman walks across the flight deck of USS John P. Murtha alongside a military crew member, with helicopters and the sunset visible in the background.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "NHQ202604100057",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:13:00",
@@ -5160,7 +7224,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Koch Walks Across the Flight Deck",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608689",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:13:03",
@@ -5174,7 +7244,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Koch on the Flight Deck",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608690",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-10 22:13:34",
@@ -5189,7 +7265,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100059)",
       "flickr_desc": "NASA astronaut Reid Wiseman, Artemis II commander is assisted off the flight deck after arriving aboard USS John P. Murtha after he and fellow crewmates NASA Astronauts Victor Glover, Christina Koch, and CSA (Canadian Space Agency) astronaut Jeremy Hansen, were extracted from their Orion spacecraft after splashdown, Friday, April 10, 2026, in the Pacific Ocean off the coast of California. NASA’s Artemis II mission took the quartet on a 10-day journey around the Moon and back to Earth. Following a splashdown at , NASA and U.S. military teams are working to bring the crewmembers and Orion spacecraft aboard the recovery ship. Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200126804",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 01:57:47",
@@ -5204,7 +7286,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100082)",
       "flickr_desc": "Teams prepare to recover NASA’s Orion spacecraft into the well deck of USS John P. Murtha in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission, which took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly 10-day journey around the Moon and back to Earth, splashed down at 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200289498",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 02:36:26",
@@ -5219,7 +7307,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100076)",
       "flickr_desc": "NASA’s Orion spacecraft is seen as the agency’s Landing and Recovery team, along with U.S. Navy personnel are seen as they prepare to recover the spacecraft into the well deck of USS John P. Murtha in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission, which took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly 10-day journey around the Moon and back to Earth, splashed down at 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200118501",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 02:46:24",
@@ -5234,7 +7328,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100084)",
       "flickr_desc": "NASA’s Orion spacecraft is seen as the agency’s Landing and Recovery team, along with U.S. Navy personnel work to recover the spacecraft into the well deck of USS John P. Murtha in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission, which took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly 10-day journey around the Moon and back to Earth, splashed down at 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199224857",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 02:50:41",
@@ -5249,7 +7349,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100083)",
       "flickr_desc": "NASA’s Landing and Recovery team, along with U.S. Navy personnel work to recover the spacecraft into the well deck of USS John P. Murtha in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission, which took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a 10-day journey around the Moon and back to Earth, splashed down at at 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200548925",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 02:52:59",
@@ -5264,7 +7370,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604100086)",
       "flickr_desc": "NASA’s Orion spacecraft is seen as the agency’s Landing and Recovery team, along with U.S. Navy personnel work to recover the spacecraft into the well deck of USS John P. Murtha in the Pacific Ocean off the coast of California, Friday, April 10, 2026. NASA’s Artemis II mission, which took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly 10-day journey around the Moon and back to Earth, splashed down at 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199225947",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 03:02:52",
@@ -5279,7 +7391,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110001)",
       "flickr_desc": "U.S. Navy personnel work alongside NASA’s Landing and Recovery team to connect lines to the agency’s Orion spacecraft is seen as they work to recover the spacecraft into the well deck of USS John P. Murtha in the Pacific Ocean off the coast of California, Saturday, April 11, 2026. NASA’s Artemis II mission, which took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly 10-day journey around the Moon and back to Earth, splashed down at 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200369004",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 03:22:37",
@@ -5294,7 +7412,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110013)",
       "flickr_desc": "NASA’s Orion spacecraft is seen as the agency’s Landing and Recovery team, along with U.S. Navy personnel work to recover the spacecraft into the well deck of USS John P. Murtha in the Pacific Ocean off the coast of California, Saturday, April 11, 2026. NASA’s Artemis II mission, which took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a 10-day journey around the Moon and back to Earth, splashed down at at 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200550355",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 03:23:42",
@@ -5309,7 +7433,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110003)",
       "flickr_desc": "NASA’s Orion spacecraft is seen as the agency’s Landing and Recovery team, along with U.S. Navy personnel work to recover the spacecraft into the well deck of USS John P. Murtha in the Pacific Ocean off the coast of California, Saturday, April 11, 2026. NASA’s Artemis II mission, which took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly 10-day journey around the Moon and back to Earth, splashed down at 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200122336",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 03:23:53",
@@ -5324,7 +7454,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110004)",
       "flickr_desc": "NASA’s Orion spacecraft is seen as the agency’s Landing and Recovery team, along with U.S. Navy personnel work to recover the spacecraft into the well deck of USS John P. Murtha in the Pacific Ocean off the coast of California, Saturday, April 11, 2026. NASA’s Artemis II mission, which took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly 10-day journey around the Moon and back to Earth, splashed down at 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200123351",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 03:24:28",
@@ -5339,7 +7475,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110006)",
       "flickr_desc": "3]NASA’s Orion spacecraft is seen as the agency’s Landing and Recovery team, along with U.S. Navy personnel work to recover the spacecraft into the well deck of USS John P. Murtha in the Pacific Ocean off the coast of California, Saturday, April 11, 2026. NASA’s Artemis II mission, which took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly 10-day journey around the Moon and back to Earth, splashed down at 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200125776",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 03:24:58",
@@ -5352,7 +7494,13 @@ const PHOTO_DATA = {
       "batch": 0,
       "title": "Orion Enters the Well Deck",
       "flickr_desc": "The Orion spacecraft, still wearing its red flotation bags, floats into the well deck of USS John P. Murtha at night as crew members watch from the railings above.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "KSC-20260411-KED01-0732",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 03:25:25",
@@ -5366,7 +7514,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Orion Winched Into the Well Deck",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9609061",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 03:25:42",
@@ -5381,7 +7535,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110007)",
       "flickr_desc": "NASA’s Orion spacecraft is seen as the agency’s Landing and Recovery team, along with U.S. Navy personnel work to recover the spacecraft into the well deck of USS John P. Murtha in the Pacific Ocean off the coast of California, Saturday, April 11, 2026. NASA’s Artemis II mission, which took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly 10-day journey around the Moon and back to Earth, splashed down at 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200126486",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 03:34:18",
@@ -5396,7 +7556,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110018)",
       "flickr_desc": "NASA’s Orion spacecraft is seen as the agency’s Landing and Recovery team, along with U.S. Navy personnel work to securethe spacecraft into the well deck of USS John P. Murtha in the Pacific Ocean off the coast of California, Saturday, April 11, 2026. NASA’s Artemis II mission, which took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a 10-day journey around the Moon and back to Earth, splashed down at , Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200304123",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 03:53:32",
@@ -5411,7 +7577,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110010)",
       "flickr_desc": "NASA’s Orion spacecraft is seen as the agency’s Landing and Recovery team, along with U.S. Navy personnel work to recover the spacecraft into the well deck of USS John P. Murtha in the Pacific Ocean off the coast of California, Saturday, April 11, 2026. NASA’s Artemis II mission, which took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly 10-day journey around the Moon and back to Earth, splashed down at 5:07 p.m. PDT (8:07 p.m. EDT). Photo Credit: (NASA/Joel Kowsky)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200377684",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 06:00:55",
@@ -5426,7 +7598,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Crew Inspects the Heat Shield",
       "flickr_desc": "The Artemis II crew, wearing blue flight suits, examines the Orion capsule's charred heat shield aboard the USS John P. Murtha after recovery. A technician points out details of the thermal protection system, which endured temperatures of nearly 5,000 degrees Fahrenheit during reentry.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55203738393",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 06:09:41",
@@ -5441,7 +7619,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Hansen Beside the Returned Capsule",
       "flickr_desc": "Canadian Space Agency astronaut Jeremy Hansen stands beside the recovered Orion crew module aboard the USS John P. Murtha, placing his hand on the scorched exterior. The heat shield's ablative tiles show the intense effects of atmospheric reentry.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55203592291",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 06:23:29",
@@ -5456,7 +7640,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Hansen Signs the Ship's Banner",
       "flickr_desc": "Astronaut Jeremy Hansen signs a commemorative Artemis II banner aboard the USS John P. Murtha after the crew's recovery from the Pacific Ocean. The banner features the mission's insignia and signatures from the ship's crew.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55203585621",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 06:24:19",
@@ -5471,7 +7661,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Koch and Hansen Sign the Banner",
       "flickr_desc": "Astronauts Christina Koch and Jeremy Hansen lean over a large Artemis II mission banner, adding their signatures aboard the USS John P. Murtha. Both wear blue flight suits covered in mission patches.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55203833379",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 06:24:32",
@@ -5486,7 +7682,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Hansen Signs the Artemis II Banner",
       "flickr_desc": "A close-up of Canadian Space Agency astronaut Jeremy Hansen carefully signing the Artemis II mission banner aboard the recovery ship. His blue flight suit displays the Canadian flag and Artemis II mission patch.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55203586701",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 06:25:21",
@@ -5501,7 +7703,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Glover Signs the Mission Banner",
       "flickr_desc": "NASA astronaut Victor Glover adds his signature to the Artemis II mission banner aboard the USS John P. Murtha. Wearing his blue flight suit adorned with mission patches, he concentrates on adding his mark alongside those of the ship's crew.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55203981890",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 06:28:35",
@@ -5516,7 +7724,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Wiseman Gears Up Below Deck",
       "flickr_desc": "Commander Reid Wiseman wears a flight deck cranial helmet and gives a shaka sign aboard the USS John P. Murtha, with astronaut Christina Koch visible behind him. Both wear blue flight suits over flight deck safety gear as they prepare for helicopter operations.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55203734853",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 06:33:56",
@@ -5530,7 +7744,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "NASA Administrator Isaacman Addresses the Crew",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9608647",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 09:11:07",
@@ -5545,7 +7765,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110022)",
       "flickr_desc": "NASA astronauts Reid Wiseman, commander; left, Christina Koch, mission specialist; CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist; and NASA astronaut Victor Glover, Artemis II pilot, right, pose for a group photo after viewing the Orion spacecraft in the well deck of USS John P. Murtha, Saturday, April 11, 2026, in the Pacific Ocean off the coast of California. The quartet splashed down Friday, April 10 at 5:07 p.m. PDT (8:07p.m. EDT). Photo Credit: (NASA/Bill Ingalls)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55199636042",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 10:08:03",
@@ -5560,7 +7786,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110114)",
       "flickr_desc": "Navy MH-60 Seahawks from Helicopter Sea Combat Squadron (HSC) 23 are seen as they arrive at Naval Air Station North Island, Calif. after flying from USS John P. Murtha with Artemis II NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist onboard, Saturday, April 11, 2026, following a splashdown in the Pacific Ocean off the coast of California at 5:07 p.m. PDT (8:07 p.m. EDT) on April 10. NASA’s Artemis II mission took the quartet on a nearly ten day journey around the Moon and back to Earth. Photo Credit: (NASA/Keegan Barber)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201805059",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 10:09:41",
@@ -5575,7 +7807,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110104)",
       "flickr_desc": "Artemis II NASA astronaut Victor Glover, pilot, is seen after being flown from USS John P. Murtha to Naval Air Station North Island on Navy MH-60 Seahawks from Helicopter Sea Combat Squadron (HSC) 23, Saturday, April 11, 2026, following a splashdown in the Pacific Ocean off the coast of California at 5:07 p.m. PDT (8:07 p.m. EDT) on April 10. NASA’s Artemis II mission took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly ten day journey around the Moon and back to Earth. Photo Credit: (NASA/Keegan Barber)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200884574",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 10:09:53",
@@ -5590,7 +7828,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110106)",
       "flickr_desc": "Artemis II NASA astronaut Reid Wiseman, commander, is seen after being flown from USS John P. Murtha to Naval Air Station North Island on Navy MH-60 Seahawks from Helicopter Sea Combat Squadron (HSC) 23, Saturday, April 11, 2026, following a splashdown in the Pacific Ocean off the coast of California at 5:07 p.m. PDT (8:07 p.m. EDT) on April 10. NASA’s Artemis II mission took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a 10-day journey around the Moon and back to Earth. Photo Credit: (NASA/Keegan Barber)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200885704",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 10:10:12",
@@ -5605,7 +7849,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110108)",
       "flickr_desc": "Artemis II NASA astronaut Reid Wiseman, commander, greets NASA team members after being flown from USS John P. Murtha to Naval Air Station North Island on Navy MH-60 Seahawks from Helicopter Sea Combat Squadron (HSC) 23, Saturday, April 11, 2026, following a splashdown in the Pacific Ocean off the coast of California at 5:07 p.m. PDT (8:07 p.m. EDT) on April 10. NASA’s Artemis II mission took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a 10-day journey around the Moon and back to Earth. Photo Credit: (NASA/Keegan Barber)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201044335",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 10:10:24",
@@ -5620,7 +7870,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110109)",
       "flickr_desc": "Artemis II NASA astronaut Reid Wiseman, commander, greets Capt. Loren “Wookie” Jacobi of Naval Base San Diego after being flown from USS John P. Murtha to Naval Air Station North Island on Navy MH-60 Seahawks from Helicopter Sea Combat Squadron (HSC) 23, Saturday, April 11, 2026, following a splashdown in the Pacific Ocean off the coast of California at 5:07 p.m. PDT (8:07 p.m. EDT) on April 10. NASA’s Artemis II mission took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly ten day journey around the Moon and back to Earth. Photo Credit: (NASA/Keegan Barber)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200638441",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 10:11:45",
@@ -5635,7 +7891,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110111)",
       "flickr_desc": "Artemis II NASA astronaut Christina Koch, mission specialist, and CSA (Canadian Space Agency) astronaut Jeremy Hansen, greet NASA team members after being flown from USS John P. Murtha to Naval Air Station North Island on Navy MH-60 Seahawks from Helicopter Sea Combat Squadron (HSC) 23, Saturday, April 11, 2026, following a splashdown in the Pacific Ocean off the coast of California at 5:07 p.m. PDT (8:07 p.m. EDT) on April 10. NASA’s Artemis II mission took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly ten day journey around the Moon and back to Earth. Photo Credit: (NASA/Keegan Barber)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201048580",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 10:12:48",
@@ -5650,7 +7912,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110113)",
       "flickr_desc": "Artemis II NASA astronaut Christina Koch, mission specialist, right, joined by Tarah Castleberry, flight surgeon, left, is seen after being flown from USS John P. Murtha to Naval Air Station North Island on Navy MH-60 Seahawks from Helicopter Sea Combat Squadron (HSC) 23, Saturday, April 11, 2026, following a splashdown in the Pacific Ocean off the coast of California at 5:07 p.m. PDT (8:07 p.m. EDT) on April 10. NASA’s Artemis II mission took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly ten day journey around the Moon and back to Earth. Photo Credit: (NASA/Keegan Barber)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200794328",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 10:15:29",
@@ -5665,7 +7933,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110116)",
       "flickr_desc": "From left to right, Chief of the Astronaut Office Scott Tingle, NASA Administrator Jared Isaacman, and CSA (Canadian Space Agency) astronaut Jeremy Hansen are seen at Naval Air Station North Island, Saturday, April 11, 2026, following a splashdown in the Pacific Ocean off the coast of California at 5:07 p.m. PDT (8:07 p.m. EDT) on April 10. NASA’s Artemis II mission took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly ten day journey around the Moon and back to Earth. Photo Credit: (NASA/Keegan Barber)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201553321",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 10:16:18",
@@ -5680,7 +7954,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Artemis II Recovery (NHQ202604110117)",
       "flickr_desc": "Artemis II mission zero gravity indicator “Rise” is seen at Naval Air Station North Island, Saturday, April 11, 2026, following a splashdown in the Pacific Ocean off the coast of California at 5:07 p.m. PDT (8:07 p.m. EDT) on April 10. NASA’s Artemis II mission took NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, mission specialist on a nearly ten day journey around the Moon and back to Earth. Photo Credit: (NASA/Keegan Barber)",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200659842",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 15:52:08",
@@ -5695,7 +7975,13 @@ const PHOTO_DATA = {
       "external": true,
       "title": "Crew Celebrates at Ellington Field",
       "flickr_desc": "The four Artemis II astronauts gather together on stage at a NASA welcome event, wearing matching navy USS John P. Murtha ballcaps. Commander Wiseman, Koch, and Hansen help pilot Glover stand in a lighthearted moment, drawing laughs from the crowd in front of a large NASA meatball logo.",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201423841",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 15:57:48",
@@ -5710,7 +7996,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022271 (April 11, 2026) - Artemis II Mission Specialist Jeremy Hansen (center) returns home to Houston, stepping off a plane at Ellington Airport near NASA's Johnson Space Center, on Saturday, April 11, 2026, following his 10-day mission around the Moon. He and his three fellow crew members launched April 1, 2026, from NASA’s Kennedy Space Center in Florida, and splashed down off the coast of California on Friday, April 10, 2026. Photo Credit: NASA/Robert Markowitz",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201661369",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 15:57:51",
@@ -5725,7 +8017,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022272 (April 11, 2026) - Artemis II Mission Specialist Jeremy Hansen returns home to Houston, stepping off a plane at Ellington Airport near NASA's Johnson Space Center, on Saturday, April 11, 2026, following his 10-day mission around the Moon. He and his three fellow crew members launched April 1, 2026, from NASA’s Kennedy Space Center in Florida, and splashed down off the coast of California on Friday, April 10, 2026. Photo Credit: NASA/Robert Markowitz",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201562253",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 15:57:58",
@@ -5740,7 +8038,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022273 (April 11, 2026) - Artemis II Mission Specialist Christina Koch returns home to Houston, stepping off a plane at Ellington Airport near NASA's Johnson Space Center, on Saturday, April 11, 2026, following her 10-day mission around the Moon. She and her three fellow crew members launched April 1, 2026, from NASA’s Kennedy Space Center in Florida, and splashed down off the coast of California on Friday, April 10, 2026. Photo Credit: NASA/Robert Markowitz",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201661254",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 15:57:59",
@@ -5755,7 +8059,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022274 (April 11, 2026) - Artemis II Pilot Victor Glover (top) and Mission Specialist Christina Koch (center) return home to Houston, stepping off a plane at Ellington Airport near NASA's Johnson Space Center, on Saturday, April 11, 2026, following their 10-day mission around the Moon. They launched April 1, 2026, from NASA’s Kennedy Space Center in Florida, and splashed down off the coast of California on Friday, April 10, 2026. Photo Credit: NASA/Robert Markowitz",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201661244",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 15:58:03",
@@ -5770,7 +8080,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022275 (April 11, 2026) - Artemis II Pilot Victor Glover returns home to Houston, stepping off a plane at Ellington Airport near NASA's Johnson Space Center, on Saturday, April 11, 2026, following his 10-day mission around the Moon. He and his three fellow crew members launched April 1, 2026, from NASA’s Kennedy Space Center in Florida, and splashed down off the coast of California on Friday, April 10, 2026. Photo Credit: NASA/Robert Markowitz",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201813500",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 15:58:06",
@@ -5785,7 +8101,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022276 (April 11, 2026) - Artemis II Commander Reid Wiseman returns home to Houston, stepping off a plane at Ellington Airport near NASA's Johnson Space Center, on Saturday, April 11, 2026, following his 10-day mission around the Moon. He and his three fellow crew members launched April 1, 2026, from NASA’s Kennedy Space Center in Florida, and splashed down off the coast of California on Friday, April 10, 2026. Photo Credit: NASA/Robert Markowitz",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201409946",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 15:58:10",
@@ -5800,7 +8122,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022277 (April 11, 2026) - Artemis II Pilot Victor Glover is greeted by NASA's Johnson Space Center Director Vanessa Wyche on his return home to Houston, at Ellington Airport on Saturday, April 11, 2026, following a 10-day trip around the Moon and back. Glover and his three fellow crew members launched April 1, 2026, from NASA’s Kennedy Space Center in Florida, and splashed down off the coast of California on Friday, April 10, 2026. Photo Credit: NASA/Robert Markowitz",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201562128",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 15:58:14",
@@ -5815,7 +8143,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022278 (April 11, 2026) - Artemis II Commander Reid Wiseman is greeted by NASA's Johnson Space Center Director Vanessa Wyche on his return home to Houston, at Ellington Airport on Saturday, April 11, 2026, following a 10-day trip around the Moon and back. Wiseman and his three fellow crew members launched April 1, 2026, from NASA’s Kennedy Space Center in Florida, and splashed down off the coast of California on Friday, April 10, 2026. Photo Credit: NASA/Robert Markowitz",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201661154",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 15:58:22",
@@ -5830,7 +8164,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022279 (April 11, 2026) - Artemis II Commander Reid Wiseman is greeted by NASA's Johnson Space Center Director Vanessa Wyche on his return home to Houston, at Ellington Airport on Saturday, April 11, 2026, following a 10-day trip around the Moon and back. Wiseman and his three fellow crew members launched April 1, 2026, from NASA’s Kennedy Space Center in Florida, and splashed down off the coast of California on Friday, April 10, 2026. Photo Credit: NASA/Robert Markowitz",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201409941",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 15:58:42",
@@ -5845,7 +8185,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022280 (April 11, 2026) - Artemis II Commander Reid Wiseman is greeted by NASA Associate Administrator Amit Kshatriya on his return home to Houston, at Ellington Airport on Saturday, April 11, 2026, following a 10-day trip around the Moon and back. Wiseman and his three fellow crew members launched April 1, 2026, from NASA’s Kennedy Space Center in Florida, and splashed down off the coast of California on Friday, April 10, 2026. Photo Credit: NASA/Robert Markowitz",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201410186",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 15:59:00",
@@ -5858,7 +8204,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": false,
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "jsc2026e022281",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 15:59:30",
@@ -5871,7 +8223,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": false,
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "jsc2026e022320",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 16:00:00",
@@ -5884,7 +8242,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": false,
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "jsc2026e022321",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 16:56:56",
@@ -5899,7 +8263,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022269 (April 11, 2026) - Artemis II Pilot Victor Glover (top) and Mission Specialist Christina Koch (center) return home to Houston, stepping off a plane at Ellington Airport near NASA's Johnson Space Center, on Saturday, April 11, 2026, following their 10-day mission around the Moon. They launched April 1, 2026, from NASA’s Kennedy Space Center in Florida, and splashed down off the coast of California on Friday, April 10, 2026. Photo Credit: NASA/David DeHoyos",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201813565",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 16:57:00",
@@ -5914,7 +8284,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022270 (April 11, 2026) - Artemis II Pilot Victor Glover returns home to Houston, stepping off a plane at Ellington Airport near NASA's Johnson Space Center, on Saturday, April 11, 2026, following his 10-day mission around the Moon. He and his three fellow crew members launched April 1, 2026, from NASA’s Kennedy Space Center in Florida, and splashed down off the coast of California on Friday, April 10, 2026. Photo Credit: NASA/David DeHoyos",
-      "enabled": false
+      "enabled": false,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201813575",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 17:00:02",
@@ -5929,7 +8305,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022292 (April 11, 2026) - NASA’s Artemis II crew, NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, shared brief remarks with friends, family, and colleagues after they landed at Ellington Airport near NASA’s Johnson Space Center in Houston on Saturday, April 11, 2026, after a nearly 10-day journey around the Moon and back to Earth. Credit: NASA/Bill Stafford",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201576423",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 17:00:15",
@@ -5944,7 +8326,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022293 (April 11, 2026) - NASA’s Artemis II crew, NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, shared brief remarks with friends, family, and colleagues after they landed at Ellington Airport near NASA’s Johnson Space Center in Houston on Saturday, April 11, 2026, after a nearly 10-day journey around the Moon and back to Earth. Credit: NASA/Bill Stafford",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201576443",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 17:00:28",
@@ -5959,7 +8347,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022294 (April 11, 2026) - CSA (Canadian Space Agency) astronaut Jeremy Hansen, shared brief remarks with friends, family, and colleagues after they landed at Ellington Airport near NASA’s Johnson Space Center in Houston on Saturday, April 11, 2026, after a nearly 10-day journey around the Moon and back to Earth. Credit: NASA/Bill Stafford",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201576368",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 17:00:33",
@@ -5974,7 +8368,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022295 (April 11, 2026) - NASA’s Artemis II crew members, NASA astronauts Reid Wiseman and CSA (Canadian Space Agency) astronaut Jeremy Hansen, during the brief remarks with friends, family, and colleagues after they landed at Ellington Airport near NASA’s Johnson Space Center in Houston on Saturday, April 11, 2026, after a nearly 10-day journey around the Moon and back to Earth. Credit: NASA/Bill Stafford",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201424106",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 17:00:41",
@@ -5989,7 +8389,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022296 (April 11, 2026) - NASA’s Artemis II mission specialist, Christina Koch, shared brief remarks with friends, family, and colleagues after they landed at Ellington Airport near NASA’s Johnson Space Center in Houston on Saturday, April 11, 2026, after a nearly 10-day journey around the Moon and back to Earth. Credit: NASA/Helen Arase Vargas",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201424136",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 17:01:41",
@@ -6004,7 +8410,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022297 (April 11, 2026) - NASA’s Artemis II crew, NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, shared brief remarks with friends, family, and colleagues after they landed at Ellington Airport near NASA’s Johnson Space Center in Houston on Saturday, April 11, 2026, after a nearly 10-day journey around the Moon and back to Earth. Credit: NASA/Helen Arase Vargas",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55200530422",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 17:21:12",
@@ -6019,7 +8431,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022310 (April 11, 2026) - NASA’s Artemis II crew, NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, shared brief remarks with friends, family, and colleagues after they landed at Ellington Airport near NASA’s Johnson Space Center in Houston on Saturday, April 11, 2026, after a nearly 10-day journey around the Moon and back to Earth. Credit: NASA/Helen Arase Vargas",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201827775",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 17:21:13",
@@ -6034,7 +8452,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022311 (April 11, 2026) - NASA’s Artemis II crew, NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, shared brief remarks with friends, family, and colleagues after they landed at Ellington Airport near NASA’s Johnson Space Center in Houston on Saturday, April 11, 2026, after a nearly 10-day journey around the Moon and back to Earth. Credit: NASA/Helen Arase Vargas",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201424021",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 17:21:16",
@@ -6049,7 +8473,13 @@ const PHOTO_DATA = {
       "external": false,
       "title": "Artemis II Crew Return",
       "flickr_desc": "jsc2026e022312 (April 11, 2026) - NASA’s Artemis II crew, NASA astronauts Reid Wiseman, commander; Victor Glover, pilot; Christina Koch, mission specialist; and CSA (Canadian Space Agency) astronaut Jeremy Hansen, shared brief remarks with friends, family, and colleagues after they landed at Ellington Airport near NASA’s Johnson Space Center in Houston on Saturday, April 11, 2026, after a nearly 10-day journey around the Moon and back to Earth. Credit: NASA/Helen Arase Vargas",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "55201675544",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 17:25:00",
@@ -6062,7 +8492,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": false,
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "jsc2026e022287",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 17:28:16",
@@ -6076,7 +8512,13 @@ const PHOTO_DATA = {
       "video": false,
       "external": true,
       "title": "Recovering the Orion Crew Module",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "9609153",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-11 17:30:00",
@@ -6089,7 +8531,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": false,
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "jsc2026e022290",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 17:32:00",
@@ -6102,7 +8550,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": false,
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "jsc2026e022292",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 17:35:00",
@@ -6115,7 +8569,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": false,
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "jsc2026e022293",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 17:40:00",
@@ -6128,7 +8588,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": false,
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "jsc2026e022310",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-11 17:42:00",
@@ -6141,7 +8607,13 @@ const PHOTO_DATA = {
       "batch": 1,
       "video": false,
       "external": false,
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "jsc2026e022312",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": "JSC"
     },
     {
       "time": "2026-04-02 00:30:00",
@@ -6154,7 +8626,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-179",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 00:35:00",
@@ -6167,7 +8645,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-241",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 00:40:00",
@@ -6180,7 +8664,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-253",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 08:21:19",
@@ -6193,7 +8683,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23107",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 08:21:22",
@@ -6206,7 +8702,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23109",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 08:21:26",
@@ -6219,7 +8721,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23114",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 08:27:41",
@@ -6232,7 +8740,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23198",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 08:30:09",
@@ -6245,7 +8759,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23282",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 08:30:51",
@@ -6258,7 +8778,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23294",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 08:31:09",
@@ -6271,7 +8797,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23303",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 08:32:52",
@@ -6284,7 +8816,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23310",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 08:32:54",
@@ -6297,7 +8835,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23311",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 14:44:56",
@@ -6310,7 +8854,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23330",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 14:48:59",
@@ -6323,7 +8873,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25345",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 14:48:59",
@@ -6336,7 +8892,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25346",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 14:53:12",
@@ -6349,7 +8911,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25359",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 14:59:09",
@@ -6362,7 +8930,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25394",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 14:59:09",
@@ -6375,7 +8949,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25395",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 14:59:09",
@@ -6388,7 +8968,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25396",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 15:03:04",
@@ -6401,7 +8987,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25403",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 15:03:47",
@@ -6414,7 +9006,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23411",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 16:54:02",
@@ -6427,7 +9025,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23482",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 16:55:38",
@@ -6440,7 +9044,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23504",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 16:55:51",
@@ -6453,7 +9063,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23514",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 17:05:29",
@@ -6466,7 +9082,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23577",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 17:05:36",
@@ -6479,7 +9101,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23578",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 17:49:05",
@@ -6492,7 +9120,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23587",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 19:17:06",
@@ -6505,7 +9139,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23674",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 19:17:12",
@@ -6518,7 +9158,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23676",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 19:43:42",
@@ -6531,7 +9177,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25461",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 19:44:04",
@@ -6544,7 +9196,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25463",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 20:22:10",
@@ -6557,7 +9215,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23716",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 20:22:10",
@@ -6570,7 +9234,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23717",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-02 20:33:42",
@@ -6583,7 +9253,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25497",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-03 19:31:29",
@@ -6596,7 +9272,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-23732",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 01:43:53",
@@ -6609,7 +9291,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-24179",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 16:22:24",
@@ -6622,7 +9310,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-9564",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 16:34:29",
@@ -6635,7 +9329,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-20318",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 16:34:49",
@@ -6648,7 +9348,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-20336",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 17:47:29",
@@ -6661,7 +9367,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-10300",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 17:49:08",
@@ -6674,7 +9386,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-10405",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 17:50:25",
@@ -6687,7 +9405,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-9566",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 17:57:47",
@@ -6700,7 +9424,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-10511",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:08:47",
@@ -6713,7 +9443,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-14273",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:09:43",
@@ -6726,7 +9462,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-14275",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:09:54",
@@ -6739,7 +9481,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-14276",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:26:57",
@@ -6752,7 +9500,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-14277",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:27:02",
@@ -6765,7 +9519,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-14279",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:27:05",
@@ -6778,7 +9538,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-14280",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:30:18",
@@ -6791,7 +9557,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-19180",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:30:38",
@@ -6804,7 +9576,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-14281",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:31:37",
@@ -6817,7 +9595,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-19204",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:31:47",
@@ -6830,7 +9614,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-19210",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:36:26",
@@ -6843,7 +9633,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-20971",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:38:08",
@@ -6856,7 +9652,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21030",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:38:15",
@@ -6869,7 +9671,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21035",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:38:15",
@@ -6882,7 +9690,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21036",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:39:06",
@@ -6895,7 +9709,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21062",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:40:32",
@@ -6908,7 +9728,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21116",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:40:34",
@@ -6921,7 +9747,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21121",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:40:42",
@@ -6934,7 +9766,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21136",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:40:47",
@@ -6947,7 +9785,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21142",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:40:47",
@@ -6960,7 +9804,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21144",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:40:49",
@@ -6973,7 +9823,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21146",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:40:50",
@@ -6986,7 +9842,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21149",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:40:50",
@@ -6999,7 +9861,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21150",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:40:54",
@@ -7012,7 +9880,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21151",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:41:31",
@@ -7025,7 +9899,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21190",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:41:36",
@@ -7038,7 +9918,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21198",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:41:37",
@@ -7051,7 +9937,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21201",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:41:45",
@@ -7064,7 +9956,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-16083",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:41:53",
@@ -7077,7 +9975,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21217",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:42:00",
@@ -7090,7 +9994,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-16091",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:42:05",
@@ -7103,7 +10013,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21227",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:42:14",
@@ -7116,7 +10032,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-9567",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:42:27",
@@ -7129,7 +10051,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21238",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:42:27",
@@ -7142,7 +10070,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21242",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:42:32",
@@ -7155,7 +10089,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21243",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:42:36",
@@ -7168,7 +10108,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-21257",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:42:40",
@@ -7181,7 +10127,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-16108",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 18:59:59",
@@ -7194,7 +10146,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-12613",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 19:01:31",
@@ -7207,7 +10165,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-12643",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 19:02:23",
@@ -7220,7 +10184,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-12663",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 19:02:28",
@@ -7233,7 +10203,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-12668",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 20:46:04",
@@ -7246,7 +10222,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-15855",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 20:52:14",
@@ -7259,7 +10241,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-15917",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 20:52:16",
@@ -7272,7 +10260,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-15920",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 20:52:19",
@@ -7285,7 +10279,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-15921",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 20:55:41",
@@ -7298,7 +10298,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-14296",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 20:57:31",
@@ -7311,7 +10317,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-14311",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 20:57:33",
@@ -7324,7 +10336,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-14312",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 20:59:32",
@@ -7337,7 +10355,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-11554",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 21:00:03",
@@ -7350,7 +10374,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-11569",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 21:00:13",
@@ -7363,7 +10393,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-11574",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-06 21:11:14",
@@ -7376,7 +10412,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-9572",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 17:23:08",
@@ -7389,7 +10431,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-29779",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 17:29:17",
@@ -7402,7 +10450,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-28283",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 17:37:16",
@@ -7415,7 +10469,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-28292",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-07 18:56:46",
@@ -7428,7 +10488,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-28154",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-08 23:52:56",
@@ -7441,7 +10507,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25205",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-08 23:53:38",
@@ -7454,7 +10526,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25206",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-08 23:54:29",
@@ -7467,7 +10545,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25207",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-08 23:55:04",
@@ -7480,7 +10564,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25210",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-08 23:55:36",
@@ -7493,7 +10583,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25211",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-08 23:55:44",
@@ -7506,7 +10602,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25212",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-08 23:56:53",
@@ -7519,7 +10621,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25214",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     },
     {
       "time": "2026-04-08 23:58:25",
@@ -7532,7 +10640,13 @@ const PHOTO_DATA = {
       "batch": 2,
       "title": "",
       "flickr_desc": "",
-      "enabled": true
+      "enabled": true,
+      "addedAt": "2026-05-11T09:39:57-04:00",
+      "source": "upstream",
+      "source_id": "ART002-E-25219",
+      "era": "mission",
+      "curator": "hankmt",
+      "center": ""
     }
   ],
   "audio": [

--- a/tools/import/DESIGN.md
+++ b/tools/import/DESIGN.md
@@ -1,0 +1,486 @@
+# Image Acquisition Pipeline — Design
+
+A re-runnable, manually-invoked tool for discovering Artemis II imagery
+(flight hardware development, crew training, and ongoing mission/post-mission
+coverage) from NASA Image Library and Flickr, downloading + resizing the
+images locally, and merging the metadata into `photos.js` via the existing
+`admin.html` review workflow.
+
+This document is the reference for everything in `tools/import/`. It captures
+the decisions we made before writing any code so future sessions (and Hank,
+if any of this is ever upstreamed) can pick up the thread.
+
+## Goal
+
+Extend the Artemis Timeline app backward in time to cover **flight hardware
+development** and **crew training**, plus keep the existing mission week
+current as new photos drop. Do this with a tool that:
+
+1. Can be re-run at any time without producing duplicates or re-downloading.
+2. Discovers from multiple sources via clean JSON APIs.
+3. Stages candidates for **manual review** in `admin.html` before they reach
+   the canonical `photos.js`.
+4. Preserves Hank's existing static-site architecture for the deployed app.
+   New tooling is **local-only** and never ships to production.
+
+## Non-Goals (for the MVP)
+
+- HTML scraping (NASA Artemis pages, Wikimedia, Internet Archive, EOL). Add
+  later if needed.
+- Scheduled / unattended runs. The pipeline supports it structurally
+  (idempotent, state-persisted) but no cron / Task Scheduler setup is part
+  of this scope.
+- Per-image LLM classification. The MVP uses keyword/regex classification
+  with a clean interface that lets us swap in an LLM later.
+- Cloud upload (R2). All staging and final files live in the local `web/`.
+  R2 push remains a separate manual `wrangler` step done by the deployer.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Timeline architecture | Single continuous timeline (2022–2026+), with an "Era" filter (`All / Pre-Flight / Mission`) layered as an orthogonal filter group |
+| Pre-Flight sub-filter | `Hardware / Training` toggleable underneath Pre-Flight |
+| First sources | NASA Image Library + Flickr API |
+| Fork strategy | Personal-first; new code in clearly-separated modules to keep upstream-PR option open |
+| Daily/rerunnable | Yes — manual invocation only for now |
+| Output mode | Discover + stage. Review via `admin.html`. Sidecar handles atomic promotion |
+| Schema additions | `addedAt` (ISO timestamp), `source`, `source_id`, `era`, `curator` |
+| Editorial principles | Captured in `EDITORIAL.md`; referenced from the Pending tab UI |
+| Write locations | All run output is gitignored; promotion is the only path to tracked files |
+| Review surface | New "Pending" tab in `admin.html` |
+| Launch | Manual: CLI (`node tools/import/sync.js`) or "Run Sync" button in `admin.html` (which calls the sidecar) |
+| Sidecar | Node `http.createServer()` bound to `127.0.0.1` only |
+| Language | Node, stdlib-first. No `package.json` if avoidable. ImageMagick CLI for resize |
+| Classifier | Layered: source-default → per-image keyword refinement → manual override in admin |
+| Confidence levels | `high` (source-default), `medium` (keyword match), `low` (mixed signals); surfaced in admin for review prioritization |
+
+## Architecture overview
+
+```
+                 ┌───────────────────────┐
+                 │   Sources (APIs)      │
+                 │   - images.nasa.gov   │
+                 │   - flickr.com/api    │
+                 └──────────┬────────────┘
+                            │ search + fetch metadata
+                            ▼
+              ┌──────────────────────────────┐
+              │  tools/import/sync.js        │
+              │  (CLI entrypoint)            │
+              │                              │
+              │  • dedup vs. state.json,     │
+              │    photos.js, inbox.json     │
+              │  • download original         │
+              │  • resize (ImageMagick CLI)  │
+              │  • classify (keyword)        │
+              │  • write to staging + inbox  │
+              └──────────────┬───────────────┘
+                             │ writes
+                             ▼
+        ┌────────────────────────────────────────────┐
+        │  tools/import/  (all gitignored)           │
+        │                                            │
+        │  state.json       — persistent dedup +     │
+        │                     last-sync cursors      │
+        │  inbox.json       — candidates pending     │
+        │                     review                 │
+        │  staging/web/     — resized JPEGs not yet  │
+        │                     promoted               │
+        │  log/             — per-run logs           │
+        └────────────────────┬───────────────────────┘
+                             │
+                             │ read via HTTP
+                             ▼
+       ┌──────────────────────────────────────────┐
+       │  tools/import/server.js                  │
+       │  (sidecar, 127.0.0.1:8001)               │
+       │                                          │
+       │  GET  /inbox      — list candidates      │
+       │  POST /promote    — move to web/+photos  │
+       │  POST /reject     — record rejection     │
+       │  POST /sync       — trigger a sync run   │
+       │  GET  /thumb/:f   — serve staged thumb   │
+       └──────────────────────┬───────────────────┘
+                              │ AJAX
+                              ▼
+                ┌─────────────────────────────┐
+                │  admin.html                 │
+                │  (new "Pending" tab)        │
+                │                             │
+                │  • thumbnails grid          │
+                │  • approve/reject/edit      │
+                │  • "Run Sync Now" button    │
+                │  • bulk actions             │
+                └──────────────┬──────────────┘
+                               │ promote
+                               ▼
+                ┌──────────────────────────────┐
+                │  Tracked files               │
+                │  - web/<filename>            │
+                │  - photos.js  (PHOTO_DATA)   │
+                └──────────────────────────────┘
+                               │
+                               │ loaded as <script>
+                               ▼
+                ┌──────────────────────────────┐
+                │  index.html  (viewer)        │
+                │  + Era filter UI             │
+                └──────────────────────────────┘
+```
+
+## Directory layout
+
+```
+tools/import/
+├── DESIGN.md           ← this file (tracked)
+├── README.md           ← how to run, troubleshoot (tracked)
+├── sync.js             ← orchestrator entrypoint (tracked)
+├── server.js           ← sidecar HTTP server (tracked)
+├── classify.js         ← keyword classifier (tracked)
+├── shared/
+│   ├── ids.js          ← getFlickrId, photoSlug helpers (tracked)
+│   ├── dates.js        ← edt() and EDT formatting (tracked)
+│   └── photos-io.js    ← read/write photos.js as JS (tracked)
+├── sources/
+│   ├── base.js         ← adapter interface contract (tracked)
+│   ├── nasa-library.js ← NASA Image Library adapter (tracked)
+│   └── flickr.js       ← Flickr adapter (tracked)
+├── state.json          ← persistent state (gitignored)
+├── inbox.json          ← candidates pending review (gitignored)
+├── staging/
+│   └── web/            ← resized JPEGs, pre-promotion (gitignored)
+└── log/
+    └── run-*.log       ← per-run logs (gitignored)
+```
+
+## Data flow per run
+
+1. **Load state.** `state.json` contains the last-sync cursor per source, the
+   set of every photo ID we've ever seen (regardless of disposition), and a
+   set of rejected IDs.
+2. **Query each source.** Use stored cursors for incremental fetch
+   (default), or ignore cursors with `--full-rescan`.
+3. **Dedup candidates.** For each fresh candidate, check:
+   - Is the stable ID already in `photos.js`? → skip (already canonical)
+   - Is it already in `inbox.json`? → skip (pending review)
+   - Is it in `state.json`'s rejected set? → skip (intentionally rejected)
+   - Is it in `state.json`'s seen set with no other disposition? → skip
+     (already processed earlier)
+4. **Download original** from the source's full-resolution URL.
+5. **Resize** via `magick convert original.jpg -resize 1600x -quality 85
+   staging/web/<filename>.jpg`. Skip if the source already provides a
+   ≤1600px web version (avoid pointless re-encoding).
+6. **Classify.** Run `classify(candidate)` to get `{ era, confidence,
+   subject_tags }`. See classification section below.
+7. **Append to inbox.json.** Include all source metadata plus the classifier
+   output, plus `addedAt: <ISO timestamp>` and `source: <adapter name>` and
+   `source_id: <stable ID at source>`.
+8. **Update state.json.** Record the candidate ID in seen set, advance the
+   per-source cursor, atomically write state back to disk.
+9. **Log** the run summary to `log/run-YYYYMMDD-HHMMSS.log`: per-source
+   counts, dedup decisions, errors, total runtime.
+
+## Schema additions
+
+Every photo entry in `photos.js` (existing and new) gains five new fields.
+Existing entries get backfilled in a one-time migration (see Schema
+Migration section).
+
+```js
+{
+  // existing fields ...
+  time: "2026-04-01 18:35:25",
+  file: "ksc_liftoff.jpg",
+  photographer: "NASA/Joel Kowsky",
+  // ...
+
+  // new fields:
+  addedAt: "2026-05-10T19:42:00-04:00",   // when this entry was added to photos.js
+  source: "nasa_library",                  // or "flickr_nasahq", "upstream", "manual"
+  source_id: "iss068e012345",              // stable ID at the source
+  era: "pre-flight-hardware",              // or "pre-flight-training" / "mission" / "post-mission"
+  curator: "johnmknight",                  // GitHub handle of the person who promoted this entry
+                                           //   "hankmt" for upstream, "johnmknight" for sync-pipeline promotions
+}
+```
+
+**`source` vs. `curator` — why both?**
+
+`source` answers *"where did this image come from?"* (discovery origin).
+`curator` answers *"who decided it belongs in the timeline?"* (editorial
+responsibility). These are different questions and conflating them loses
+information. The sync pipeline discovers candidates from many sources; a
+single human curator (you) decides which ones to promote. Future-you, or
+Hank if anything is ever upstreamed, should be able to attribute either
+question independently.
+
+**Era values:**
+
+- `pre-flight-hardware` — SLS, Orion, mobile launcher, integration, pad ops,
+  facility activity at Michoud/Stennis/KSC. Anything mechanical/structural.
+- `pre-flight-training` — Crew training: NBL, simulators, T-38, suit fit
+  checks, water survival, parabolic flight, briefings.
+- `mission` — Anything during April 1–11, 2026 mission week.
+- `post-mission` — Recovery, debrief, post-flight crew activities, future
+  press events tied to Artemis II specifically.
+
+## Classification approach
+
+Per-image classification is a function from a candidate record to a verdict:
+
+```js
+function classify(candidate) {
+  return {
+    era: "pre-flight-hardware",     // string from the enum above
+    confidence: "high",              // "high" | "medium" | "low"
+    subject_tags: ["SLS", "core-stage", "Michoud"]
+  };
+}
+```
+
+### Layered logic
+
+1. **Source default.** Each adapter can declare a baseline era for its
+   output. Example: `flickr_nasamarshall` → `pre-flight-hardware` (Marshall
+   = engines/SLS). When the classifier sees a source-default that matches
+   keyword signals, confidence is `high`.
+
+2. **Date window.** If the photo's timestamp falls within April 1–11, 2026
+   inclusive, the era is `mission` (confidence `high`) regardless of source
+   or keywords. Post-Apr 11, 2026 with mission-related keywords →
+   `post-mission`.
+
+3. **Keyword scan.** Concatenate `title + description + tags` and run case-
+   insensitive regex matches:
+
+   | Era | Sample keywords |
+   |---|---|
+   | `pre-flight-hardware` | `core stage`, `RS-25`, `engine test`, `Stennis`, `Michoud`, `VAB`, `Vehicle Assembly Building`, `integration`, `rollout`, `pad 39B`, `mobile launcher`, `umbilical`, `service module`, `crew module`, `Lockheed`, `Northrop`, `Boeing core`, `green run`, `wet dress` |
+   | `pre-flight-training` | `NBL`, `Neutral Buoyancy Lab`, `T-38`, `simulator`, `sim`, `training`, `suit fit`, `OCSS`, `survival training`, `parabolic`, `Zero-G`, `centrifuge`, `EVA training`, `mission rehearsal`, `briefing` |
+   | `mission` | Date window match (Apr 1–11, 2026) OR `liftoff`, `splashdown`, `lunar flyby`, `TLI`, `translunar`, `in-flight`, `Orion in space` |
+   | `post-mission` | `recovery`, `crew debrief`, `post-flight`, `welcome home`, plus date > Apr 11, 2026 |
+
+4. **Combine.** If source-default and keyword agree → `high` confidence. If
+   keyword overrides source-default → `medium`. If no signal at all →
+   `unknown` era + `low` confidence (admin reviews manually).
+
+### Why this is enough for the MVP
+
+Hank's existing 519 entries demonstrate that captions on Artemis II imagery
+are reasonably caption-rich. We're not classifying ambiguous nature photos.
+Most candidates will have either "SLS rollout" or "NBL training" or
+"liftoff" in their description, and the regex will catch them.
+
+The admin UI surfaces the classifier verdict + confidence on each pending
+card, with the era as an editable dropdown. You correct mistakes in
+seconds; rejections feed back into state.json so the same photo doesn't
+return on the next run with the same wrong verdict.
+
+### Future LLM upgrade
+
+`classify.js` exports the same `classify(candidate)` interface regardless
+of implementation. A future version can swap the keyword regex for a Claude
+API call (per-image, ~$0.001 each). No other code changes.
+
+## Source adapter contract
+
+All adapters in `tools/import/sources/` export the same async function:
+
+```js
+// sources/base.js — interface only
+export async function discover({ sinceCursor, fullRescan }) {
+  // returns: { candidates: [...], nextCursor: <opaque value> }
+}
+```
+
+A `candidate` is the normalized record:
+
+```js
+{
+  source: "nasa_library",          // adapter name
+  source_id: "iss068e012345",      // stable ID at source
+  source_url: "https://images.nasa.gov/details-iss068e012345",
+  image_url: "https://images-assets.nasa.gov/.../orig.jpg",
+  title: "Crew member Reid Wiseman during T-38 training",
+  description: "...",
+  photographer: "NASA/Joel Kowsky",
+  location: "Ellington Field, Houston",
+  camera: "",                      // EXIF if available, else ""
+  settings: "",                    // EXIF if available, else ""
+  taken_at: "2024-06-15T13:00:00-04:00",  // best-available timestamp in EDT
+  tags: ["Artemis II", "training", "T-38"],
+  spacecraft: false,               // from inside the spacecraft? (true/false)
+  video: false,                    // is it a video?
+  source_default_era: "unknown"    // adapter's baseline era guess
+}
+```
+
+Each adapter is independently testable (`node tools/import/sources/nasa-library.js`
+prints first N candidates as JSON to stdout for inspection).
+
+## Sidecar API
+
+Local-only HTTP server bound to `127.0.0.1:8001` (port configurable).
+
+### `GET /inbox`
+Returns the current `inbox.json` array.
+
+### `POST /promote`
+Body:
+```json
+{ "candidates": [
+    { "source_id": "iss068e012345", "filename": "wiseman_t38_2024_06_15.jpg",
+      "title": "...", "time": "...", "era": "pre-flight-training", "photographer": "...", ... }
+] }
+```
+Action: for each entry, move the staged JPEG to `web/`, append to
+`photos.js` (preserving JS syntax — the file has to remain valid JavaScript,
+not JSON), remove from `inbox.json`. Atomic — failures roll back.
+
+### `POST /reject`
+Body: `{ "source_ids": ["..."] }`. Adds these to `state.json`'s rejected
+set, removes from `inbox.json` and `staging/web/`.
+
+### `POST /sync`
+Spawns `node sync.js` as a child process. Returns immediately with a job
+ID; the run streams to `log/run-*.log` and on completion the inbox is
+refreshed.
+
+### `GET /thumb/:filename`
+Serves a staged JPEG from `staging/web/<filename>`. Used by `admin.html`'s
+Pending tab to render thumbnails.
+
+### `GET /status`
+Returns `{ lastRun: <ISO>, lastRunSummary: {...}, syncing: <bool> }`.
+
+## admin.html — Pending tab
+
+Implementation outline (does NOT replace existing Photos / Audio tabs):
+
+- New tab button next to "Audio": **"Pending (N)"** with the live inbox count.
+- Body renders a grid of candidate cards. Each card shows:
+  - Thumbnail (from `GET /thumb/:filename`)
+  - Title (editable)
+  - Time (editable)
+  - Photographer (editable)
+  - Location (editable)
+  - Era dropdown (editable, defaults to classifier verdict)
+  - Confidence badge (visual cue — green/yellow/gray)
+  - **Quality badge** (visual cue indicating completeness — see below)
+  - Source link (opens original)
+  - Per-card: Approve / Reject / Edit
+- Toolbar:
+  - "Run Sync Now" button (`POST /sync`)
+  - "Promote Selected (N)" button — only enabled when ≥1 card is checked
+  - "Reject Selected (N)" button
+  - Filter by confidence / era / source / quality (similar to existing filter chips)
+  - **Link to `EDITORIAL.md`** — always one click away during review
+- After promotion: refresh `PHOTO_DATA` in memory (the same object the rest
+  of admin already mutates) so the Photos tab shows new entries immediately.
+- After "Export photos.js" from the Photos tab: nothing changes — the
+  promotion has already mutated the file on disk via the sidecar, the
+  Export button still produces a downloadable snapshot of the current
+  in-memory data.
+
+### Quality badges
+
+Each candidate is scored against the `EDITORIAL.md` must-have checklist
+(meaningful title / defensible timestamp / photographer credit / description
+longer than title / unambiguous era). The card surfaces this as a visual
+badge:
+
+| Badge | Meaning | Behaviour |
+|---|---|---|
+| Green | All must-haves present | Default sort to bottom of pending list |
+| Yellow | One or two fields weak | Mid-list, edit-friendly |
+| Red | Major fields missing or implausible | Top of list, hardest to accidentally promote |
+
+Promotion isn't blocked at any quality level — the reviewer is the final
+authority — but the visual ordering pushes attention toward the entries
+most likely to need work, and away from the entries that look clean enough
+to bulk-approve.
+
+### Bulk-action safety
+
+The Pending tab includes a soft confirmation when promoting more than a
+threshold count in one action (configurable; default 25). The dialog
+shows the era / source / quality breakdown of the selection so the
+reviewer knows what they're committing to before clicking through.
+
+## index.html — Era filter
+
+New filter button group in the existing controls row, between the
+"All / Crew Photos / etc." row and the camera filters:
+
+```
+ERA: [All] [Pre-Flight] [Mission] [Post-Mission]
+       └── (when Pre-Flight active, show: [Hardware] [Training])
+```
+
+Logic mirrors the existing camera filter pattern: clicking exclusively
+selects one era at a time; Hardware/Training are multi-select beneath
+Pre-Flight. State stored in the same `filteredPhotos` array.
+
+Activity bars and trajectory canvas don't need conditional code — they
+already only render meaningful data during mission week timestamps. The
+distance widgets already return "On the ground" pre-launch.
+
+**Mobile filter popup** gets a matching "Era" section above the existing
+"Where" / "What Camera" / "Media Type" sections.
+
+## Schema migration
+
+One-time backfill of existing 519 photo entries in `photos.js`. Each
+entry receives the five new fields if it's missing them; entries that
+already have a given field keep their existing value.
+
+- `era` → `"mission"` for every existing entry. Hank's curation spans
+  March 27 – April 11 2026; all of it falls within his self-defined
+  "mission" narrative even though the actual flight window is Apr 1–11.
+  Reclassify by hand later if any entry needs `pre-flight-hardware` or
+  `post-mission`.
+- `addedAt` → A single fixed ISO-EDT timestamp captured at the start of
+  the migration run, applied to every migrated entry. All upstream
+  entries therefore share the same `addedAt` value — a reliable signal
+  that anything with this exact timestamp came from Hank's curation.
+- `source` → `"upstream"` (i.e., from Hank's original `photos.js`).
+- `source_id` → existing `getFlickrId(file)` result, or filename without
+  extension as fallback.
+- `curator` → `"hankmt"`. Hank curated all 519 upstream entries.
+
+Migration script: `node tools/import/migrate.js`. Writes back to
+`photos.js`. **Idempotent per field** — each entry's missing fields get
+filled in; entries fully migrated are left alone. This means we can
+extend the schema later by adding another default and re-running
+without worrying about earlier passes.
+
+Run `node tools/import/migrate.js --dry-run` to preview without writing.
+
+## Open operational questions
+
+These are deliberately deferred until after the MVP runs end-to-end.
+
+1. **Initial keyword/query list for each source.** What search terms hit
+   the right balance of recall vs. noise? Tunable per-adapter at the top
+   of `sources/<adapter>.js`. Start with broad ("Artemis II", "SLS Block 1",
+   "Orion crew module", "Artemis crew training") and refine.
+2. **LLM-based classifier upgrade.** Same `classify()` interface, replace
+   regex with Claude API call. Cost / latency / rate-limit handling.
+3. **Hardware vs. Training sub-tags as separate filters.** Currently part
+   of the era enum. Could be split into a separate `subject` field if more
+   granularity is needed (e.g., `subject: "engine-test"`).
+4. **Scheduled runs.** Architecture supports it; setup is out of scope.
+
+## Glossary
+
+- **Candidate** — a record produced by a source adapter, not yet in the inbox.
+- **Inbox** — pending candidates awaiting human review (`inbox.json`).
+- **Promotion** — moving an inbox entry into the canonical `photos.js` +
+  staged JPEG into `web/`.
+- **Rejection** — explicit decision to never include this candidate;
+  recorded in state so it doesn't reappear.
+- **Source default era** — an adapter's baseline guess about what era its
+  output belongs to (e.g., "Marshall photostream → hardware").
+- **Sidecar** — the local Node HTTP server (`server.js`) that gives
+  `admin.html` access to the filesystem-bound pipeline state.

--- a/tools/import/EDITORIAL.md
+++ b/tools/import/EDITORIAL.md
@@ -1,0 +1,208 @@
+# Editorial Principles
+
+What makes a candidate photo worth promoting into `photos.js`.
+
+The Artemis Timeline is a **curated** collection, not a comprehensive
+archive. Hank's upstream 519 entries are the editorial baseline. New
+entries from the sync pipeline have to meet the same bar — that's the
+whole point of the `admin.html` Pending review step.
+
+This document is referenced from the Pending tab UI, so a reviewer is
+always one click away from the rules.
+
+## Mission
+
+Help a curious viewer follow the Artemis II mission as a story across
+time and space. The collection should:
+
+- Be **chronologically continuous** — minimize unexplained gaps in coverage
+- Be **photographically meaningful** — favor images that show people doing
+  things, hardware in context, or vantage points only this mission offers
+- Be **honest** — include moments of difficulty, failure, and quiet routine
+  alongside the heroic ones; don't only show the highlight reel
+- Be **factually rigorous** — every entry's metadata should be verifiable
+  against an authoritative source (NASA, photographer credit, mission log)
+
+## Inclusion checklist
+
+A candidate should be promoted only if it meets these criteria.
+
+### Must have
+
+- [ ] **It's actually Artemis II.** Not Artemis I, Artemis III, Apollo,
+  Commercial Crew, or generic SLS stock art. When loose API queries return
+  adjacent missions, reject.
+- [ ] **A meaningful title.** Not a filename, not "Untitled," not just the
+  date. The title is what shows in the viewer's metadata panel and in
+  shared link previews — it has to read.
+- [ ] **A defensible timestamp.** To the minute when known, to the day when
+  not. If the source provides no time, you have to research and assign one
+  before promoting. Photos with no resolvable date go in the reject pile.
+- [ ] **A photographer credit.** "NASA" is acceptable as a fallback when
+  the specific photographer is unknown. Never invent a name.
+- [ ] **A description.** At minimum, a sentence longer than the title. The
+  description is where context lives — facility name, what's happening in
+  the frame, what came before / after.
+- [ ] **An era classification.** One of `pre-flight-hardware`,
+  `pre-flight-training`, `mission`, or `post-mission`. The classifier
+  proposes one; you override if it's wrong.
+
+### Should have
+
+- Source URL pointing to the original (so a reader can verify or get a
+  larger version)
+- Camera + lens + exposure settings, when EXIF or source metadata provides
+  them (matches the level of detail in Hank's existing entries)
+- Location (facility name and city when relevant — "NASA Stennis Space
+  Center, MS" is better than just "NASA")
+- Subject tags (helpful for future facets — e.g., `["RS-25", "engine test",
+  "Stennis"]`)
+
+## Rejection criteria
+
+Reject without guilt when:
+
+- The image isn't Artemis II. Boundary cases (Artemis I imagery occasionally
+  shows up in Artemis II searches) → reject; lean restrictive.
+- It's an **artist's concept**, **CGI render**, or **diagram** rather than
+  a photograph. The collection is photographic.
+- It's a **logo, mission patch, or graphic** with no photographic content.
+- The image is a **near-duplicate** of an existing entry — same scene from
+  the same camera within seconds. Pick the best of a burst, reject the rest.
+- The description is **substantially incorrect** and you can't fix it. A
+  vague description is workable; a wrong one is worse than nothing.
+- It's **watermarked**, **low-resolution**, or **clearly a thumbnail** when
+  a better version exists at the source.
+- The **photographer or rights are unclear** in a way that makes inclusion
+  risky. Hank's collection avoids privately-copyrighted material; ours
+  should too.
+
+## Field-by-field standards
+
+### `title`
+Descriptive, declarative, no clickbait. Match the tone of Hank's existing
+titles — "Christina Koch Smiles Before Launch," "Crew Walkout From the O&C
+Building," "SLS Glows at Sunset on Pad 39B." If the title is the same as
+the description, consolidate them.
+
+### `time`
+EDT, "YYYY-MM-DD HH:MM:SS." If only a date is known, use noon EDT
+("12:00:00") as a defensible midpoint and note the imprecision in the
+description ("approximately mid-afternoon"). Never invent precision.
+
+For mission-week photos, cross-reference against known events (liftoff
+2026-04-01 18:35:25, splashdown 2026-04-10 20:07:27). For pre-flight
+hardware/training photos, the source's EXIF or caption date is usually
+correct.
+
+### `photographer`
+Format: `"NASA/<Photographer Name>"` for credited NASA photographers
+(matching Hank's convention). `"NASA"` for uncredited. For non-NASA
+sources, include the affiliation: `"Lockheed Martin/<Name>"`, `"USCG/<Name>"`,
+`"Boeing"`.
+
+### `location`
+Specific enough to mean something. "Kennedy Space Center" is fine when
+the building isn't known; "Neil Armstrong Operations and Checkout Building,
+Kennedy Space Center" is better when it is. Use the facility's preferred
+name (NASA generally provides this).
+
+### `camera` and `settings`
+Copy verbatim from EXIF when available. Don't infer.
+
+### `description` / `flickr_desc`
+Two to four sentences. What's in the frame, what's happening, why it
+matters in the mission narrative. Don't recap the title. Don't editorialize.
+Match the level of detail Hank brings — informative but not exhaustive.
+
+### `era`
+- `pre-flight-hardware` — SLS / Orion / facility / integration / pad ops
+  before launch
+- `pre-flight-training` — crew training, simulators, suit fit, T-38, NBL,
+  briefings
+- `mission` — Apr 1–11, 2026 (Hank's curated window)
+- `post-mission` — recovery, debrief, post-flight events tied specifically
+  to Artemis II
+
+When in doubt between two adjacent eras, prefer the more specific one.
+A training event held during mission week is still `pre-flight-training`
+in spirit, but you'll find vanishingly few of these.
+
+### `curator`
+Auto-set by the sync pipeline to the GitHub handle doing the promotion.
+Never edit manually — this field is the editorial signature.
+
+## Ambiguity rules
+
+- **Artemis II vs. another Artemis mission** → lean reject. Artemis II is
+  specifically the second crewed mission with Wiseman / Glover / Koch /
+  Hansen.
+- **Crew portrait vs. publicity shot** → both included, but tagged
+  honestly (the era stays the same; the description should make the
+  context clear).
+- **Hardware photo with no specific people in frame** → fine. Hank's
+  collection includes plenty of empty-spacecraft shots.
+- **Photo containing the SLS but the subject is something else** → judge
+  by intent. A T-shirt in the gift shop with an SLS print on it: reject.
+  The SLS rolling past a palm tree on transport: include.
+- **Date is "circa 2024" with no month** → either research it to better
+  precision or skip. Better to wait than fudge.
+
+## Crew anonymity caveat
+
+Per the FAQ, the four Artemis II astronauts collectively asked not to be
+individually credited as photographers for in-mission photos they took.
+**Don't attribute specific in-flight photos to a single astronaut even if
+EXIF or social media suggests it.** Use `"Artemis II Crew"` as the
+photographer for any photo taken from inside the spacecraft, unless
+NASA's caption specifically credits the person.
+
+This applies to:
+- Photos with `spacecraft: true`
+- Photos clearly taken from inside Orion during mission week
+- Photos credited to specific astronauts on Flickr/social posts that don't
+  also have a NASA HQ caption
+
+Ground photos with NASA-issued photographer credits (KSC, NHQ, JSC) are
+fine to attribute normally.
+
+## Voice & style
+
+- **Factual.** State what's in the frame. Avoid editorial adjectives
+  ("breathtaking," "stunning," "historic" — those are for the reader to
+  decide).
+- **Conversational where Hank is conversational.** Match the existing
+  prose. If Hank wrote "the crew rides the elevator," don't write "the
+  crewmembers utilized the conveyance mechanism."
+- **No political framing.** The collection is about a space mission. Keep
+  it about the mission. References to broader political context belong in
+  the FAQ, not photo descriptions.
+- **Active voice.** "Reid Wiseman boards the spacecraft" is better than
+  "The spacecraft is boarded by Reid Wiseman."
+
+## Voice — when to override the classifier
+
+The keyword classifier will be wrong sometimes. Trust your eye over its
+verdict. Common errors to watch for:
+
+- Tagged `pre-flight-hardware` because the caption mentions "SLS" but the
+  subject is actually a crew member at a press event with a model SLS
+  behind them → re-tag `pre-flight-training` or `mission`
+- Tagged `mission` because the date falls in early April 2026 but the
+  subject is actually post-flight debrief → re-tag `post-mission`
+- Tagged `unknown` because the caption is empty but the filename or
+  visual context makes the era obvious → tag it manually with high
+  confidence
+
+## When in doubt
+
+If you're not sure whether to promote a candidate:
+
+1. **Reject it.** A passed-over photo can be re-discovered on the next
+   sync; a bad promotion has to be hand-cleaned out of `photos.js`.
+2. Note your reasoning in the rejection (the sidecar's `/reject` endpoint
+   accepts an optional `reason` string that gets stored in `state.json`).
+3. If your reasoning is "I'm not sure if it's Artemis II," you almost
+   certainly want to reject.
+4. If your reasoning is "I'd want this in a 'broader Artemis' collection
+   but not this specific one," reject — the collection's focus is Artemis II.

--- a/tools/import/README.md
+++ b/tools/import/README.md
@@ -1,0 +1,95 @@
+# `tools/import/` — Image Acquisition Pipeline
+
+Local-only tooling for discovering new Artemis II imagery from NASA Image
+Library and Flickr, staging it for review, and merging into `photos.js`.
+
+- **Design rationale and architecture:** [`DESIGN.md`](./DESIGN.md)
+- **Editorial principles** (what makes a candidate worth promoting): [`EDITORIAL.md`](./EDITORIAL.md)
+
+## Prerequisites
+
+- **Node.js 20+** (uses `fetch`, `fs/promises`, `crypto.randomUUID` from
+  stdlib — no `npm install` required).
+- **ImageMagick** (`magick` on `PATH`). Used to resize originals to
+  1600px-wide JPEGs. Verify with `magick --version`.
+- **A Flickr API key** — already present in
+  `../../fetch-flickr-descriptions.js`. Reused here.
+
+No `package.json`, no `node_modules/`, no build step.
+
+## Quick start
+
+```sh
+# From the repo root
+node tools/import/sync.js              # incremental sync from all sources
+node tools/import/sync.js --full-rescan  # ignore cursors; re-fetch everything
+
+node tools/import/server.js            # start the sidecar on 127.0.0.1:8001
+                                       # (admin.html "Pending" tab uses this)
+
+node tools/import/migrate.js           # one-time backfill of existing photos.js
+                                       # (idempotent; safe to re-run)
+```
+
+To review pending candidates in the browser:
+
+```sh
+python -m http.server 8000   # serve the static site
+node tools/import/server.js  # start the sidecar (separate terminal)
+```
+
+Then open `http://localhost:8000/admin.html` and use the **Pending** tab.
+
+## Directory contents
+
+| Path | Purpose | Tracked? |
+|---|---|---|
+| `DESIGN.md` | Architecture + decisions reference | Yes |
+| `EDITORIAL.md` | Curation principles (what to promote, what to reject) | Yes |
+| `README.md` | This file | Yes |
+| `sync.js` | Orchestrator — entry point for a discovery run | Yes |
+| `server.js` | Sidecar HTTP server (`127.0.0.1:8001`) | Yes |
+| `classify.js` | Keyword-based era classifier | Yes |
+| `migrate.js` | One-time backfill of existing `photos.js` entries | Yes |
+| `shared/ids.js` | Stable-ID extraction (Flickr / DVIDS / NASA / etc.) | Yes |
+| `shared/dates.js` | EDT timestamp parsing and formatting | Yes |
+| `shared/photos-io.js` | Read / write `photos.js` while preserving JS syntax | Yes |
+| `sources/base.js` | Adapter interface contract | Yes |
+| `sources/nasa-library.js` | NASA Image Library adapter | Yes |
+| `sources/flickr.js` | Flickr API adapter | Yes |
+| `state.json` | Persistent dedup + per-source sync cursors | **No** |
+| `inbox.json` | Candidates pending review | **No** |
+| `staging/web/` | Resized JPEGs awaiting promotion | **No** |
+| `log/` | Per-run logs | **No** |
+
+## Operational notes
+
+- **Idempotency.** Every run dedupes against `photos.js`, `inbox.json`, and
+  the seen+rejected sets in `state.json`. Safe to re-run at any cadence.
+- **Atomic promotion.** When you promote candidates via `admin.html`, the
+  sidecar moves files into `web/` and rewrites `photos.js` in a single
+  transaction. If anything fails partway, nothing changes on disk.
+- **No network at runtime.** The deployed site never calls these APIs.
+  Discovery is entirely a local, offline-from-end-user-perspective process.
+- **R2 upload is separate.** This pipeline only writes to local `web/`.
+  Pushing to Cloudflare R2 is still done manually with `wrangler r2 object put`
+  by whoever deploys the site.
+
+## Troubleshooting
+
+**`magick: command not found`** — Install ImageMagick and ensure `magick`
+is on `PATH`. On Windows: `winget install ImageMagick.ImageMagick`.
+
+**Sidecar shows `EADDRINUSE`** — Port 8001 is taken. Change `PORT` at the
+top of `server.js`, or kill whatever's holding the port.
+
+**Pending tab in admin.html shows "Sidecar offline"** — Start
+`node tools/import/server.js` in a second terminal alongside
+`python -m http.server`.
+
+**Classifier got an era wrong** — Edit the dropdown in the Pending tab
+before promoting. Rejections feed back into `state.json` so the same
+mistake doesn't recur.
+
+**Want to start over** — Delete `state.json`, `inbox.json`, and
+`staging/web/*`. The next run will re-discover everything fresh.

--- a/tools/import/classify.js
+++ b/tools/import/classify.js
@@ -1,0 +1,342 @@
+/**
+ * Keyword-based era classifier.
+ *
+ * Takes a normalized Candidate and returns:
+ *   { era, confidence, subject_tags, reason }
+ *
+ * Layered logic per DESIGN.md:
+ *   1. Date window  — taken_at within Apr 1–11 2026 → "mission" (high)
+ *   2. Source default — adapter's baseline era guess, if any
+ *   3. Keyword scan — regex matches on title + description + tags
+ *   4. Combine — high if multiple signals agree, medium if only one,
+ *                low/unknown if nothing matches.
+ *
+ * The whole module is pure (input → output), no side effects, no I/O.
+ * A future revision could swap the keyword regex for a Claude API call
+ * and the rest of the pipeline wouldn't notice.
+ */
+
+'use strict';
+
+const ERA_PRE_HARDWARE = 'pre-flight-hardware';
+const ERA_PRE_TRAINING = 'pre-flight-training';
+const ERA_MISSION      = 'mission';
+const ERA_POST_MISSION = 'post-mission';
+const ERA_UNKNOWN      = 'unknown';
+
+// Mission window matches Hank's curated narrative — covers his actual span
+// (March 27 through April 11, 2026). Liftoff was Apr 1 18:35:25 EDT.
+const MISSION_START_DATE = '2026-03-27';
+const MISSION_END_DATE   = '2026-04-11';
+
+/**
+ * Per-era keyword patterns. Order within each list doesn't matter; we
+ * only count "did any pattern match?" Patterns are case-insensitive and
+ * use word-boundaries where possible to avoid false positives (e.g. we
+ * don't want "training" inside "intraining" to match).
+ */
+const KEYWORDS = {
+  [ERA_PRE_HARDWARE]: [
+    /\bcore stage\b/i,
+    /\bRS-25\b/i,
+    /\bengine test\b/i,
+    /\bgreen run\b/i,
+    /\bwet dress\b/i,
+    /\bstennis\b/i,
+    /\bmichoud\b/i,
+    /\bMSFC\b/i,
+    /\bmarshall space\b/i,
+    /\bSLS\b/i,
+    /\bspace launch system\b/i,
+    /\bsolid rocket booster\b/i,
+    /\bSRB\b/i,
+    /\bservice module\b/i,
+    /\bcrew module\b/i,
+    /\bmobile launcher\b/i,
+    /\bumbilical\b/i,
+    /\bVAB\b/i,
+    /\bvehicle assembly building\b/i,
+    /\brollout\b/i,
+    /\bintegration\b/i,
+    /\bpad 39B\b/i,
+    /\blaunch pad\b/i,
+    /\blockheed\b/i,
+    /\bnorthrop\b/i,
+    /\bboeing/i,
+  ],
+  [ERA_PRE_TRAINING]: [
+    /\bNBL\b/i,
+    /\bneutral buoyancy lab\b/i,
+    /\bT-38\b/i,
+    /\bsimulator\b/i,
+    /\bsimulation\b/i,
+    /\bsuit fit\b/i,
+    /\bOCSS\b/i,
+    /\bsurvival training\b/i,
+    /\bparabolic flight\b/i,
+    /\bzero[\s-]?g\b/i,
+    /\bcentrifuge\b/i,
+    /\bEVA training\b/i,
+    /\bmission rehearsal\b/i,
+    /\bgeology training\b/i,
+    /\blunar observ/i,
+    /\bcrew training\b/i,
+    /\btraining session\b/i,
+    /\bbriefing\b/i,
+    /\bORION mockup\b/i,
+    /\bspace vehicle mockup\b/i,
+  ],
+  [ERA_MISSION]: [
+    /\bliftoff\b/i,
+    /\blaunch\s*(day|sequence)?\b/i,
+    /\bsplashdown\b/i,
+    /\blunar flyby\b/i,
+    /\bTLI\b/i,
+    /\btrans[\s-]?lunar injection\b/i,
+    /\bin[\s-]?flight\b/i,
+    /\bin\s*space\b/i,
+    /\bcrew walkout\b/i,
+    /\bsuit[\s-]?up\b/i,
+    /\bO&C building\b/i,
+    /\bOperations and Checkout\b/i,
+    /\barmstrong operations\b/i,
+  ],
+  [ERA_POST_MISSION]: [
+    /\brecovery operation\b/i,
+    /\bcrew debrief\b/i,
+    /\bpost[\s-]?flight\b/i,
+    /\bwelcome home\b/i,
+    /\bdebrief\b/i,
+    /\bUSS John P\.? Murtha\b/i,
+  ],
+};
+
+/**
+ * Decide era from the candidate's date alone.
+ * Returns one of the era constants, or null when the date isn't usable.
+ */
+function dateBasedEra(takenAt) {
+  if (!takenAt || typeof takenAt !== 'string') return null;
+  // Compare just the YYYY-MM-DD portion via lexicographic order (works
+  // because the format is sortable).
+  const datePart = takenAt.slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(datePart)) return null;
+
+  if (datePart >= MISSION_START_DATE && datePart <= MISSION_END_DATE) {
+    return ERA_MISSION;
+  }
+  if (datePart > MISSION_END_DATE) {
+    return ERA_POST_MISSION;
+  }
+  return null; // before mission window — could be hardware or training; let
+               // keyword scan decide
+}
+
+/**
+ * Run all keyword patterns against a set of named source fields. Each
+ * field is scanned independently so we can tell the reviewer which field
+ * a match came from (title vs description vs tags).
+ *
+ * Returns:
+ *   - matches[]: every pattern hit, with the matched text and where it
+ *                lives. One match record per regex hit (so the same
+ *                pattern matching twice in one field produces two records).
+ *   - hits: { era → count } total across all fields.
+ *   - keywordEra: era with the most hits (KEYWORDS declaration order
+ *                  for ties).
+ *   - matchCount: hits[keywordEra].
+ *
+ * A `match` record looks like:
+ *   { kind: "keyword",
+ *     pattern: "\\bgeology training\\b",  // regex source for display
+ *     excerpt: "geology training",          // actual matched substring
+ *     era: "pre-flight-training",
+ *     sourceField: "title" | "description" | "tags",
+ *     index: 14                              // start index in the field text
+ *   }
+ *
+ * This shape was chosen for forward-compatibility with an LLM classifier
+ * that would return `{ kind: "rationale", text, era }` records instead.
+ * Renderers should switch on `kind`.
+ */
+function scanKeywords(fields) {
+  const hits = {};
+  for (const era of Object.keys(KEYWORDS)) hits[era] = 0;
+  const matches = [];
+
+  if (!fields || typeof fields !== 'object') {
+    return { keywordEra: null, matchCount: 0, hits, matches };
+  }
+
+  for (const [sourceField, fieldText] of Object.entries(fields)) {
+    if (!fieldText) continue;
+    for (const [era, patterns] of Object.entries(KEYWORDS)) {
+      for (const re of patterns) {
+        // Use a fresh global-flag regex so .exec() can iterate multiple hits
+        // without mutating the original pattern's lastIndex.
+        const g = new RegExp(re.source, re.flags.includes('g') ? re.flags : re.flags + 'g');
+        let m;
+        while ((m = g.exec(fieldText)) !== null) {
+          hits[era]++;
+          matches.push({
+            kind: 'keyword',
+            pattern: re.source,
+            excerpt: m[0],
+            era,
+            sourceField,
+            index: m.index,
+          });
+          // Prevent zero-length-match infinite loop (paranoia).
+          if (m.index === g.lastIndex) g.lastIndex++;
+        }
+      }
+    }
+  }
+
+  // Tie-breaking: KEYWORDS declaration order.
+  let bestEra = null;
+  let bestCount = 0;
+  for (const era of Object.keys(KEYWORDS)) {
+    if (hits[era] > bestCount) {
+      bestEra = era;
+      bestCount = hits[era];
+    }
+  }
+  return { keywordEra: bestEra, matchCount: bestCount, hits, matches };
+}
+
+/**
+ * Extract subject tags from a text blob — every keyword bucket that had
+ * any hits becomes a tag. Useful for the admin Pending tab to show "this
+ * looked like hardware AND mission" when keyword signals are mixed.
+ */
+function extractSubjectTags(hits) {
+  return Object.keys(hits).filter(era => hits[era] > 0);
+}
+
+/**
+ * Build the named field map the classifier scans. Keeping fields separate
+ * (vs. one concatenated blob) lets the highlighter tell the reviewer
+ * which field a match came from.
+ */
+function candidateFields(candidate) {
+  return {
+    title: candidate.title || '',
+    description: candidate.description || '',
+    tags: Array.isArray(candidate.tags) ? candidate.tags.join(' • ') : '',
+  };
+}
+
+/**
+ * Classify a candidate. Pure function.
+ *
+ * @param {object} candidate
+ * @returns {{era: string, confidence: 'high'|'medium'|'low',
+ *            subject_tags: string[], reason: string}}
+ */
+function classify(candidate) {
+  const sourceDefault = candidate.source_default_era || ERA_UNKNOWN;
+  const dateBased = dateBasedEra(candidate.taken_at);
+  const fields = candidateFields(candidate);
+  const { keywordEra, matchCount, hits, matches } = scanKeywords(fields);
+
+  let era, confidence, reason;
+
+  // Strongest signal: a date in the mission window. Trust it absolutely —
+  // Hank's mission curation includes pre-launch days (March 27+).
+  if (dateBased === ERA_MISSION) {
+    era = ERA_MISSION;
+    confidence = 'high';
+    reason = 'date in mission window';
+
+  // Two corroborating signals: keyword AND source-default agree.
+  } else if (keywordEra && sourceDefault !== ERA_UNKNOWN && keywordEra === sourceDefault) {
+    era = keywordEra;
+    confidence = 'high';
+    reason = 'source default + keywords agree';
+
+  // Date past mission window with mission-related keywords → post-mission.
+  } else if (dateBased === ERA_POST_MISSION && keywordEra === ERA_POST_MISSION) {
+    era = ERA_POST_MISSION;
+    confidence = 'high';
+    reason = 'post-mission date + keywords';
+
+  // Strong keyword match (2+ hits) — likely correct.
+  } else if (keywordEra && matchCount >= 2) {
+    era = keywordEra;
+    confidence = 'high';
+    reason = `${matchCount} keyword matches`;
+
+  // Single keyword match — possibly right, possibly noise.
+  } else if (keywordEra) {
+    era = keywordEra;
+    confidence = 'medium';
+    reason = '1 keyword match';
+
+  // Date-only signal — post-mission edge case (no keyword corroboration).
+  } else if (dateBased === ERA_POST_MISSION) {
+    era = ERA_POST_MISSION;
+    confidence = 'medium';
+    reason = 'date past mission window';
+
+  // Source default as fallback.
+  } else if (sourceDefault !== ERA_UNKNOWN) {
+    era = sourceDefault;
+    confidence = 'medium';
+    reason = 'source default';
+
+  // Nothing matched.
+  } else {
+    era = ERA_UNKNOWN;
+    confidence = 'low';
+    reason = 'no signals';
+  }
+
+  // Evidence: enumerate the matches that drove the verdict, plus any
+  // structural signals (date window, source default) that contributed.
+  // The shape is extensible — quality-score and center-source evidence
+  // is attached later by sync.js, and a future LLM classifier can return
+  // { kind: "rationale", text, era } records here instead.
+  const evidence = {
+    era_matches: matches.slice(),
+  };
+  if (dateBased) {
+    evidence.era_matches.push({
+      kind: 'date_window',
+      pattern: `taken_at in ${MISSION_START_DATE}..${MISSION_END_DATE}`,
+      excerpt: candidate.taken_at || '',
+      era: dateBased,
+      sourceField: 'taken_at',
+    });
+  }
+  if (sourceDefault !== ERA_UNKNOWN) {
+    evidence.era_matches.push({
+      kind: 'source_default',
+      pattern: `${candidate.source} → ${sourceDefault}`,
+      excerpt: candidate.source || '',
+      era: sourceDefault,
+      sourceField: 'source',
+    });
+  }
+
+  return {
+    era,
+    confidence,
+    subject_tags: extractSubjectTags(hits),
+    reason,
+    evidence,
+  };
+}
+
+module.exports = {
+  classify,
+  // Exported for tests / inspection:
+  dateBasedEra,
+  scanKeywords,
+  KEYWORDS,
+  ERA_PRE_HARDWARE,
+  ERA_PRE_TRAINING,
+  ERA_MISSION,
+  ERA_POST_MISSION,
+  ERA_UNKNOWN,
+};

--- a/tools/import/migrate.js
+++ b/tools/import/migrate.js
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * One-time schema migration for photos.js.
+ *
+ * Adds six new fields to every photo entry that doesn't already have them:
+ *
+ *   addedAt   - ISO-8601 timestamp in EDT (single fixed value for the whole
+ *               migration run, marking when this fork picked up the schema)
+ *   source    - "upstream" for migrated entries (where the entry came from
+ *               into this fork). Future values from the sync pipeline:
+ *               "nasa_library", "flickr_nasahq", "flickr_kennedy", etc.
+ *   source_id - getFlickrId(file) result, or the filename stem as a fallback
+ *   era       - "mission" — all 519 existing entries are within Hank's
+ *               mission-curated narrative. Adjust by hand later if any need
+ *               reclassification to "pre-flight-hardware" / "pre-flight-
+ *               training" / "post-mission".
+ *   curator   - "hankmt" — Hank curated all upstream entries. Entries added
+ *               via the sync pipeline + admin Pending tab will be stamped
+ *               with "johnmknight" (or whichever GitHub handle is doing the
+ *               promotion). Separates editorial responsibility from source
+ *               of origin.
+ *   center    - NASA center code (KSC/JSC/MSFC/SSC/MAF/HQ/etc.) derived from
+ *               the existing `location` field. Empty for in-flight, recovery,
+ *               and non-NASA locations (which is most of Hank's data — most
+ *               of his collection is taken in space or on the recovery ship).
+ *
+ * Idempotent per-field. Re-running adds only the fields each entry is still
+ * missing; entries that already have everything are left alone. This means
+ * we can extend the schema later by adding another check below and re-
+ * running migrate.js without worrying about earlier passes.
+ *
+ * Audio entries are NOT touched — they share the schema only loosely and
+ * the era / curator concepts don't apply (all audio is mission window,
+ * all upstream).
+ *
+ * Usage:
+ *   node tools/import/migrate.js           # writes back to photos.js
+ *   node tools/import/migrate.js --dry-run # report only, don't write
+ */
+
+'use strict';
+
+const path = require('path');
+const { readPhotosJs, writePhotosJs } = require('./shared/photos-io');
+const { getFlickrId } = require('./shared/ids');
+const { isoEdt } = require('./shared/dates');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const PHOTOS_JS = path.join(REPO_ROOT, 'photos.js');
+
+const MIGRATION_TS = isoEdt();   // single timestamp for the whole run
+
+function deriveSourceId(file) {
+  const fid = getFlickrId(file);
+  if (fid) return fid;
+  // Fallback: strip extension, keep everything else as the ID.
+  return file.replace(/\.[^.]+$/, '');
+}
+
+/**
+ * Derive a NASA center code from an entry's existing `location` field.
+ * Returns "" if no recognizable center can be inferred (which is correct
+ * for in-flight, recovery, and non-NASA locations).
+ */
+const LOCATION_TO_CENTER_EXACT = {
+  'Kennedy Space Center': 'KSC',
+  'Liftoff': 'KSC',                              // launch event happens at KSC
+  'Ellington Field, Houston': 'JSC',             // JSC's T-38 base
+  'Mission Control, Houston': 'JSC',
+  'Science Evaluation Room, Houston': 'JSC',
+  'Space Vehicle Mockup Facility, Houston, TX': 'JSC',
+};
+
+function deriveCenter(entry) {
+  const loc = entry.location;
+  if (!loc) return '';
+
+  // Exact match first
+  if (LOCATION_TO_CENTER_EXACT[loc]) return LOCATION_TO_CENTER_EXACT[loc];
+
+  // Fuzzy fallback for variants (e.g., "Marshall Space Flight Center, Huntsville, AL")
+  const lower = loc.toLowerCase();
+  if (lower.includes('kennedy'))   return 'KSC';
+  if (lower.includes('marshall'))  return 'MSFC';
+  if (lower.includes('stennis'))   return 'SSC';
+  if (lower.includes('michoud'))   return 'MAF';
+  if (lower.includes('johnson'))   return 'JSC';
+  if (lower.includes('houston'))   return 'JSC';   // most Houston refs are JSC-adjacent
+  if (lower.includes('goddard'))   return 'GSFC';
+  if (lower.includes('glenn'))     return 'GRC';
+  if (lower.includes('langley'))   return 'LARC';
+  if (lower.includes('headquart')) return 'HQ';
+
+  return '';
+}
+
+/**
+ * The canonical schema defaults for upstream entries. Each entry in the
+ * existing photos.js gets these fields added IF they're missing. Order
+ * matters for the touched-fields report only.
+ */
+const UPSTREAM_DEFAULTS = [
+  ['addedAt',   () => MIGRATION_TS],
+  ['source',    () => 'upstream'],
+  ['source_id', (e) => deriveSourceId(e.file)],
+  ['era',       () => 'mission'],
+  ['curator',   () => 'hankmt'],
+  ['center',    (e) => deriveCenter(e)],
+];
+
+/**
+ * Apply per-field defaults to an entry. Returns the (possibly updated) entry
+ * plus a list of fields that were added. Empty `added` array means nothing
+ * changed for this entry.
+ */
+function migrateEntry(entry) {
+  const updated = { ...entry };
+  const added = [];
+  for (const [field, valueFn] of UPSTREAM_DEFAULTS) {
+    if (updated[field] === undefined) {
+      updated[field] = valueFn(entry);
+      added.push(field);
+    }
+  }
+  return { entry: updated, added };
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+
+  console.log(`[migrate] reading ${PHOTOS_JS}`);
+  const data = await readPhotosJs(PHOTOS_JS);
+  console.log(`[migrate] loaded: ${data.photos.length} photos, ${data.audio.length} audio`);
+  console.log(`[migrate] migration timestamp: ${MIGRATION_TS}`);
+
+  const photos = [];
+  const fieldCounts = {};         // { fieldName: number of entries that got it added }
+  let entriesTouched = 0;          // entries that got at least one field added
+  let entriesUntouched = 0;        // already fully migrated
+
+  for (const p of data.photos) {
+    const { entry, added } = migrateEntry(p);
+    photos.push(entry);
+    if (added.length === 0) {
+      entriesUntouched++;
+    } else {
+      entriesTouched++;
+      for (const f of added) fieldCounts[f] = (fieldCounts[f] || 0) + 1;
+    }
+  }
+
+  console.log(`[migrate] entries touched:   ${entriesTouched}`);
+  console.log(`[migrate] entries untouched: ${entriesUntouched}`);
+  if (entriesTouched > 0) {
+    console.log('[migrate] fields added (count per field):');
+    for (const [f, n] of Object.entries(fieldCounts)) {
+      console.log(`           ${f}: ${n}`);
+    }
+  }
+
+  if (dryRun) {
+    console.log('[migrate] dry run — not writing.');
+    if (entriesTouched > 0) {
+      const sample = photos[0];
+      console.log('[migrate] sample entry after migration:');
+      console.log(JSON.stringify({
+        time: sample.time,
+        file: sample.file,
+        title: sample.title,
+        addedAt: sample.addedAt,
+        source: sample.source,
+        source_id: sample.source_id,
+        era: sample.era,
+        curator: sample.curator,
+      }, null, 2));
+    }
+    return;
+  }
+
+  if (entriesTouched === 0) {
+    console.log('[migrate] nothing to do.');
+    return;
+  }
+
+  const updated = { ...data, photos };
+  await writePhotosJs(PHOTOS_JS, updated);
+  console.log(`[migrate] wrote ${PHOTOS_JS}`);
+}
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error('[migrate] FAILED:', err.message);
+    console.error(err.stack);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  // Exported for tests + ad-hoc inspection. Not part of any public API.
+  deriveCenter,
+  deriveSourceId,
+  migrateEntry,
+  UPSTREAM_DEFAULTS,
+  LOCATION_TO_CENTER_EXACT,
+};

--- a/tools/import/normalize.js
+++ b/tools/import/normalize.js
@@ -1,0 +1,149 @@
+/**
+ * Candidate normalizers.
+ *
+ * These run after a source adapter returns candidates but before the
+ * classifier sees them. The goal is to bring source-specific quirks into
+ * line with Hank's existing photos.js conventions so the downstream
+ * classifier, admin UI, and viewer all see consistent data.
+ *
+ * Two normalizers right now:
+ *
+ *   normalizePhotographer  - convert source-specific photographer credit
+ *                            formats into Hank's canonical "NASA/First Last"
+ *                            shape (or "NASA" when only the affiliation is known).
+ *   normalizeTimestamp     - replace "fake-precise" timestamps (a source's
+ *                            midnight-UTC date_created that happens to convert
+ *                            to 20:00:00 EDT) with an honest noon-EDT
+ *                            placeholder. Per EDITORIAL.md: never invent
+ *                            precision.
+ *
+ * Each normalizer is pure (input → output) and side-effect-free.
+ */
+
+'use strict';
+
+/**
+ * Convert various photographer-credit formats into "NASA/First Last"
+ * canonical form.
+ *
+ * Examples in:
+ *   "ROBERT MARKOWITZ  NASA-JSC"       → "NASA/Robert Markowitz"
+ *   "James Blair - NASA - JSC"         → "NASA/James Blair"
+ *   "NASA/Joel Kowsky"                 → "NASA/Joel Kowsky" (passthrough)
+ *   "NASA"                             → "NASA"
+ *   "" / null / undefined              → "NASA"
+ *   "Aubrey Gemignani"                 → "NASA/Aubrey Gemignani" (assumed NASA
+ *                                        when affiliation not stated; safe
+ *                                        for Artemis II since all our sources
+ *                                        are NASA-derived)
+ *
+ * @param {string} raw
+ * @returns {string}
+ */
+function normalizePhotographer(raw) {
+  if (raw === null || raw === undefined) return 'NASA';
+  let s = String(raw).trim();
+  if (!s) return 'NASA';
+
+  // Already canonical "NASA/Name" — keep as-is (just clean whitespace).
+  if (/^NASA\/[^ ].*/i.test(s)) {
+    return s.replace(/^NASA\/\s*/i, 'NASA/').replace(/\s+/g, ' ');
+  }
+
+  // Plain "NASA" or "NASA-JSC" / "NASA / JSC" → just "NASA"
+  if (/^NASA([-\s\/]+[A-Z]{2,5})?$/i.test(s)) return 'NASA';
+
+  // Strip trailing/leading NASA affiliation markers in any common form.
+  //   "ROBERT MARKOWITZ  NASA-JSC"
+  //   "James Blair - NASA - JSC"
+  //   "Aubrey Gemignani / NASA"
+  //   "Bill Ingalls (NASA)"
+  // Handle "(NASA)" as a whole token first so we don't leave a stray
+  // closing paren behind.
+  s = s.replace(/[\s,]*\(NASA[\s\/-]*[A-Z]{0,5}\)[\s,]*/gi, ' ');
+  s = s.replace(/[\s,()\/-]*NASA[\s,()\/-]*[A-Z]{2,5}\b/gi, '');   // "NASA-JSC" etc.
+  s = s.replace(/[\s,()\/-]+NASA\b/gi, '');                          // trailing/embedded NASA
+
+  // Collapse whitespace, strip orphaned separators.
+  s = s.replace(/\s+/g, ' ').replace(/^[\s,()\/-]+|[\s,()\/-]+$/g, '').trim();
+  if (!s) return 'NASA';
+
+  // Title-case the name. We use a simple per-word capitalize that handles
+  // common surname patterns (Mc, Mac, O'Brien, De La Vega) reasonably well.
+  s = titleCaseName(s);
+
+  return 'NASA/' + s;
+}
+
+function titleCaseName(s) {
+  return s
+    .toLowerCase()
+    .replace(/\b([a-z])/g, c => c.toUpperCase())
+    .replace(/\b(Mc|Mac)([a-z])/g, (m, p, c) => p + c.toUpperCase())
+    .replace(/'([a-z])/g, (m, c) => "'" + c.toUpperCase());
+}
+
+/**
+ * Apply the honest-timestamp policy. If a timestamp's time-of-day is a
+ * known "fake precision" sentinel (00:00:00 UTC → 20:00:00 EDT, or already
+ * 00:00:00 EDT), replace it with 12:00:00 EDT and signal that this is a
+ * date-only entry to the caller.
+ *
+ * Returns { time, datePrecisionOnly }.
+ *
+ *   "2024-07-15 20:00:00"    → { time: "2024-07-15 12:00:00", datePrecisionOnly: true }
+ *   "2024-07-15 00:00:00"    → { time: "2024-07-15 12:00:00", datePrecisionOnly: true }
+ *   "2024-07-15 13:42:07"    → { time: "2024-07-15 13:42:07", datePrecisionOnly: false }
+ *   ""                       → { time: "",                     datePrecisionOnly: false }
+ *
+ * @param {string} timeStr  "YYYY-MM-DD HH:MM:SS" format, EDT
+ * @returns {{time: string, datePrecisionOnly: boolean}}
+ */
+function normalizeTimestamp(timeStr) {
+  if (!timeStr || typeof timeStr !== 'string') {
+    return { time: '', datePrecisionOnly: false };
+  }
+  const m = timeStr.match(/^(\d{4}-\d{2}-\d{2})\s(\d{2}:\d{2}:\d{2})$/);
+  if (!m) return { time: timeStr, datePrecisionOnly: false };
+
+  const datePart = m[1];
+  const timePart = m[2];
+
+  // Sentinel times that signal "date is reliable; time is a placeholder":
+  //   00:00:00 — caller already in EDT-input
+  //   20:00:00 — UTC midnight converted to EDT
+  if (timePart === '00:00:00' || timePart === '20:00:00') {
+    return { time: `${datePart} 12:00:00`, datePrecisionOnly: true };
+  }
+  return { time: timeStr, datePrecisionOnly: false };
+}
+
+/**
+ * Apply all normalizers to a candidate. Returns a new candidate object;
+ * does not mutate the input. Adds a `_normalized` debug field tracking
+ * which normalizers fired (useful for the admin Pending tab to surface
+ * "this was a date-only entry — set the time before promoting").
+ *
+ * @param {object} candidate
+ * @returns {object}
+ */
+function normalizeCandidate(candidate) {
+  const photographer = normalizePhotographer(candidate.photographer);
+  const tsResult = normalizeTimestamp(candidate.taken_at);
+
+  return {
+    ...candidate,
+    photographer,
+    taken_at: tsResult.time,
+    _normalized: {
+      photographerChanged: photographer !== candidate.photographer,
+      datePrecisionOnly: tsResult.datePrecisionOnly,
+    },
+  };
+}
+
+module.exports = {
+  normalizePhotographer,
+  normalizeTimestamp,
+  normalizeCandidate,
+};

--- a/tools/import/server.js
+++ b/tools/import/server.js
@@ -1,0 +1,476 @@
+#!/usr/bin/env node
+/**
+ * Local HTTP sidecar for the acquisition pipeline.
+ *
+ * Bound to 127.0.0.1 only — never exposed beyond loopback. The admin.html
+ * Pending tab makes fetch() calls against this server's endpoints while
+ * the rest of the static site is served by `python -m http.server` or
+ * similar.
+ *
+ * Endpoints (all return JSON, all accept JSON for POST):
+ *
+ *   GET  /status          - { lastRunAt, inboxCount, seenCount, rejectedCount }
+ *   GET  /inbox           - the current inbox array
+ *   POST /promote         - promote a list of candidates to photos.js
+ *   POST /reject          - mark a list of candidates as rejected
+ *   POST /sync            - run sync.js as a child process
+ *
+ * Usage:
+ *   node tools/import/server.js [--port 8001]
+ *
+ * The server is intentionally minimal — no auth, no rate limiting, no
+ * persistent connections. It exists so admin.html can mutate filesystem-
+ * bound state without the user having to drop to a terminal.
+ */
+
+'use strict';
+
+const http = require('http');
+const fs = require('fs/promises');
+const fsSync = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+const { URL } = require('url');
+
+const { readPhotosJs, writePhotosJs } = require('./shared/photos-io');
+const { isoEdt } = require('./shared/dates');
+
+const REPO_ROOT  = path.resolve(__dirname, '..', '..');
+const PHOTOS_JS  = path.join(REPO_ROOT, 'photos.js');
+const WEB_DIR    = path.join(REPO_ROOT, 'web');
+const STATE_JSON = path.join(__dirname, 'state.json');
+const INBOX_JSON = path.join(__dirname, 'inbox.json');
+const SYNC_JS    = path.join(__dirname, 'sync.js');
+
+const DEFAULT_PORT = 8001;
+const BIND_HOST    = '127.0.0.1';
+
+// ---------------------------------------------------------------------------
+// JSON file helpers (atomic writes)
+// ---------------------------------------------------------------------------
+
+async function loadJsonOr(filePath, fallback) {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (e) {
+    if (e.code === 'ENOENT') return fallback;
+    throw e;
+  }
+}
+
+async function writeJsonAtomic(filePath, data) {
+  const tmp = filePath + '.tmp';
+  await fs.writeFile(tmp, JSON.stringify(data, null, 2));
+  await fs.rename(tmp, filePath);
+}
+
+async function loadState() {
+  const s = await loadJsonOr(STATE_JSON, {
+    seen: [], rejected: [], lastRunAt: null, cursors: {},
+  });
+  s.seen     = s.seen     || [];
+  s.rejected = s.rejected || [];
+  s.cursors  = s.cursors  || {};
+  return s;
+}
+
+async function loadInbox() {
+  const i = await loadJsonOr(INBOX_JSON, []);
+  return Array.isArray(i) ? i : [];
+}
+
+// ---------------------------------------------------------------------------
+// HTTP utilities
+// ---------------------------------------------------------------------------
+
+function sendJson(res, status, body) {
+  // CORS: allow loopback callers from any port (e.g. python -m http.server :8000).
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Cache-Control': 'no-store',
+  });
+  res.end(JSON.stringify(body, null, 2));
+}
+
+function sendError(res, status, message, detail) {
+  sendJson(res, status, { error: message, detail: detail || null });
+}
+
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    let size = 0;
+    req.on('data', chunk => {
+      size += chunk.length;
+      if (size > 1024 * 1024) {           // 1 MB safety cap
+        req.destroy();
+        reject(new Error('request body too large'));
+        return;
+      }
+      body += chunk.toString('utf8');
+    });
+    req.on('end', () => {
+      if (!body) { resolve({}); return; }
+      try { resolve(JSON.parse(body)); }
+      catch (e) { reject(new Error('invalid JSON body: ' + e.message)); }
+    });
+    req.on('error', reject);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Image download + filename derivation for promotion
+// ---------------------------------------------------------------------------
+
+/**
+ * Sanitize a source_id into a safe filename body. Strip path separators
+ * and characters that don't belong in a filename. Keep dots out of the
+ * stem so the extension is unambiguous.
+ */
+function safeFilenameStem(s) {
+  return String(s)
+    .replace(/[\\/]/g, '_')
+    .replace(/[^a-zA-Z0-9_\-]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 120);
+}
+
+function extensionFromUrl(url) {
+  const m = url.match(/\.([a-z0-9]{2,5})(?:\?.*)?$/i);
+  if (!m) return 'jpg';
+  const ext = m[1].toLowerCase();
+  if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'mp4'].includes(ext)) return ext === 'jpeg' ? 'jpg' : ext;
+  return 'jpg';
+}
+
+function deriveFilename(candidate) {
+  const stem = safeFilenameStem(candidate.source_id || candidate.source + '_unnamed');
+  const ext = extensionFromUrl(candidate.image_url || '');
+  return `${stem}.${ext}`;
+}
+
+/**
+ * Download the candidate's image_url to web/<filename>. Streams straight
+ * to a temp file, then renames into place. Returns the local filename.
+ */
+async function downloadImage(candidate) {
+  if (!candidate.image_url) throw new Error('candidate has no image_url');
+  const filename = deriveFilename(candidate);
+  const destPath = path.join(WEB_DIR, filename);
+  const tmpPath  = destPath + '.dl-tmp';
+
+  // Refuse to clobber an existing file. If it's already there, assume it's
+  // the same image (filename is derived deterministically from source_id)
+  // and skip the download.
+  try {
+    await fs.access(destPath);
+    return filename;
+  } catch (e) { /* doesn't exist — proceed */ }
+
+  const res = await fetch(candidate.image_url);
+  if (!res.ok) {
+    throw new Error(`image_url ${candidate.image_url} returned HTTP ${res.status}`);
+  }
+  const buffer = Buffer.from(await res.arrayBuffer());
+  await fs.mkdir(WEB_DIR, { recursive: true });
+  await fs.writeFile(tmpPath, buffer);
+  await fs.rename(tmpPath, destPath);
+  return filename;
+}
+
+// ---------------------------------------------------------------------------
+// Promotion logic: inbox candidate -> photos.js entry
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an inbox candidate (plus optional user edits) into a photos.js
+ * entry matching Hank's schema convention. The returned object has only
+ * the fields that belong in photos.js — internal pipeline fields like
+ * _normalized, classified, thumb_url, source_url, image_url, tags are
+ * dropped.
+ */
+function candidateToPhotoEntry(candidate, edits, filename, curator) {
+  const e = { ...candidate, ...edits };   // edits override candidate
+
+  // Photos.js fields, in (roughly) Hank's order:
+  return {
+    time:         e.taken_at || e.time || '',
+    file:         filename,
+    photographer: e.photographer || 'NASA',
+    location:     e.location || '',
+    camera:       e.camera || '',
+    settings:     e.settings || '',
+    spacecraft:   !!e.spacecraft,
+    batch:        0,
+    title:        e.title || '',
+    flickr_desc:  e.description || e.flickr_desc || '',
+    enabled:      true,
+    // Schema-additions fields:
+    addedAt:   isoEdt(),
+    source:    candidate.source || 'manual',
+    source_id: candidate.source_id || '',
+    era:       (e.classified && e.classified.era) || e.era || 'unknown',
+    curator:   curator || 'johnmknight',
+    center:    e.center || '',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+async function routeStatus(req, res) {
+  const [state, inbox] = await Promise.all([loadState(), loadInbox()]);
+  sendJson(res, 200, {
+    ok: true,
+    lastRunAt: state.lastRunAt,
+    inboxCount: inbox.length,
+    seenCount: state.seen.length,
+    rejectedCount: state.rejected.length,
+  });
+}
+
+async function routeInbox(req, res) {
+  const inbox = await loadInbox();
+  sendJson(res, 200, { ok: true, candidates: inbox });
+}
+
+/**
+ * POST /promote
+ * Body: { items: [{ source_id: "...", edits: { ... }, curator: "..." }, ...] }
+ *
+ * For each item:
+ *   - find candidate in inbox by source_id
+ *   - download image_url to web/<derived_filename>
+ *   - build photos.js entry, append to PHOTO_DATA.photos
+ *   - remove from inbox
+ *   - record source_id in state.seen (it stays there anyway from earlier
+ *     sync runs, but explicit re-add is safe)
+ *
+ * Writes inbox.json + photos.js atomically. If any item fails its download
+ * the whole batch rolls back (no partial promotion).
+ */
+async function routePromote(req, res) {
+  const body = await readJsonBody(req);
+  const items = Array.isArray(body.items) ? body.items : null;
+  if (!items || items.length === 0) {
+    return sendError(res, 400, 'body.items required and must be non-empty');
+  }
+
+  const [photoData, inbox] = await Promise.all([readPhotosJs(PHOTOS_JS), loadInbox()]);
+  const candidateById = new Map(inbox.map(c => [c.source_id, c]));
+
+  // First pass: validate all items
+  const plans = [];
+  for (const item of items) {
+    if (!item.source_id) return sendError(res, 400, 'each item needs source_id');
+    const candidate = candidateById.get(item.source_id);
+    if (!candidate) return sendError(res, 404, `no inbox candidate ${item.source_id}`);
+    plans.push({ candidate, edits: item.edits || {}, curator: item.curator });
+  }
+
+  // Second pass: download images for everything before mutating anything.
+  // If a download fails, we abort cleanly.
+  const downloaded = [];
+  try {
+    for (const p of plans) {
+      const merged = { ...p.candidate, ...p.edits };
+      const filename = await downloadImage(merged);
+      downloaded.push({ ...p, filename });
+    }
+  } catch (e) {
+    return sendError(res, 502, 'image download failed during promotion', e.message);
+  }
+
+  // Third pass: mutate photos.js + inbox atomically
+  for (const p of downloaded) {
+    const entry = candidateToPhotoEntry(p.candidate, p.edits, p.filename, p.curator);
+    photoData.photos.push(entry);
+  }
+  const remainingInbox = inbox.filter(
+    c => !downloaded.some(p => p.candidate.source_id === c.source_id)
+  );
+
+  await writePhotosJs(PHOTOS_JS, photoData);
+  await writeJsonAtomic(INBOX_JSON, remainingInbox);
+
+  sendJson(res, 200, {
+    ok: true,
+    promoted: downloaded.length,
+    promotedIds: downloaded.map(p => p.candidate.source_id),
+    photosCount: photoData.photos.length,
+    inboxCount: remainingInbox.length,
+  });
+}
+
+/**
+ * POST /reject
+ * Body: { source_ids: ["...", ...], reason: "optional" }
+ *
+ * Removes the matching candidates from inbox.json and adds their IDs to
+ * state.rejected so a future sync run won't re-discover them.
+ */
+async function routeReject(req, res) {
+  const body = await readJsonBody(req);
+  const ids = Array.isArray(body.source_ids) ? body.source_ids : null;
+  if (!ids || ids.length === 0) {
+    return sendError(res, 400, 'body.source_ids required and must be non-empty');
+  }
+
+  const [state, inbox] = await Promise.all([loadState(), loadInbox()]);
+  const idSet = new Set(ids);
+  const removed = inbox.filter(c => idSet.has(c.source_id)).map(c => c.source_id);
+  const remaining = inbox.filter(c => !idSet.has(c.source_id));
+
+  for (const id of removed) {
+    if (!state.rejected.includes(id)) state.rejected.push(id);
+  }
+
+  await writeJsonAtomic(INBOX_JSON, remaining);
+  await writeJsonAtomic(STATE_JSON, state);
+
+  sendJson(res, 200, {
+    ok: true,
+    rejected: removed.length,
+    rejectedIds: removed,
+    inboxCount: remaining.length,
+  });
+}
+
+/**
+ * POST /sync
+ * Body: { query?, centers?, limit?, fullRescan?, source? }
+ *
+ * Spawns sync.js as a child process with the given options. Waits for it
+ * to complete (sync runs are typically a few seconds to a minute) then
+ * returns the run summary plus the new inbox count.
+ *
+ * For long-running syncs the client should still call this endpoint —
+ * we keep the connection open until the child exits. A future revision
+ * can switch to a streaming or polling protocol if runs get slow enough
+ * to matter.
+ */
+async function routeSync(req, res) {
+  const body = await readJsonBody(req);
+
+  const args = [SYNC_JS];
+  if (body.limit)       args.push('--limit', String(body.limit | 0));
+  if (body.fullRescan)  args.push('--full-rescan');
+  if (body.source)      args.push('--source', String(body.source));
+  if (body.query)       args.push('--query', String(body.query));
+  if (Array.isArray(body.centers) && body.centers.length) {
+    args.push('--centers', body.centers.join(','));
+  }
+
+  const child = spawn(process.execPath, args, { cwd: REPO_ROOT });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', d => stdout += d.toString());
+  child.stderr.on('data', d => stderr += d.toString());
+
+  child.on('close', async (code) => {
+    const inbox = await loadInbox();
+    const status = code === 0 ? 200 : 500;
+    sendJson(res, status, {
+      ok: code === 0,
+      exitCode: code,
+      stdout,
+      stderr,
+      inboxCount: inbox.length,
+    });
+  });
+  child.on('error', err => {
+    sendError(res, 500, 'sync child process failed to start', err.message);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Server bootstrap
+// ---------------------------------------------------------------------------
+
+function dispatch(req, res) {
+  // CORS preflight
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    });
+    res.end();
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+  const route = req.method + ' ' + url.pathname;
+
+  // Route table. Each handler returns a Promise we catch at the bottom.
+  const routes = {
+    'GET /status':   routeStatus,
+    'GET /inbox':    routeInbox,
+    'POST /promote': routePromote,
+    'POST /reject':  routeReject,
+    'POST /sync':    routeSync,
+  };
+
+  const handler = routes[route];
+  if (!handler) {
+    return sendError(res, 404, `no route ${route}`);
+  }
+
+  Promise.resolve(handler(req, res)).catch(err => {
+    console.error(`[server] ${route} failed:`, err);
+    if (!res.headersSent) sendError(res, 500, err.message);
+  });
+}
+
+function parseArgs(argv) {
+  const args = { port: DEFAULT_PORT };
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--port') args.port = parseInt(argv[++i], 10) || DEFAULT_PORT;
+    else if (argv[i] === '-h' || argv[i] === '--help') args.help = true;
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node tools/import/server.js [options]
+
+Options:
+  --port N    Bind port (default ${DEFAULT_PORT})
+  -h         Show this help
+
+The server binds to 127.0.0.1 only. It exposes the acquisition
+pipeline's state to the admin Pending tab and accepts mutations
+(promote / reject / sync).`);
+}
+
+function start() {
+  const args = parseArgs(process.argv);
+  if (args.help) { printHelp(); return; }
+
+  const server = http.createServer(dispatch);
+  server.listen(args.port, BIND_HOST, () => {
+    console.log(`[server] listening on http://${BIND_HOST}:${args.port}`);
+    console.log(`[server] routes:`);
+    console.log(`           GET  /status`);
+    console.log(`           GET  /inbox`);
+    console.log(`           POST /promote`);
+    console.log(`           POST /reject`);
+    console.log(`           POST /sync`);
+    console.log(`[server] press Ctrl-C to stop`);
+  });
+
+  process.on('SIGINT',  () => { console.log('\n[server] shutting down'); server.close(() => process.exit(0)); });
+  process.on('SIGTERM', () => { server.close(() => process.exit(0)); });
+}
+
+if (require.main === module) {
+  start();
+}
+
+module.exports = { start, dispatch };

--- a/tools/import/shared/dates.js
+++ b/tools/import/shared/dates.js
@@ -1,0 +1,117 @@
+/**
+ * EDT timestamp parsing and formatting.
+ *
+ * The Artemis Timeline app stores every timestamp as a "YYYY-MM-DD HH:MM:SS"
+ * string in Eastern Daylight Time (UTC-4). This module is the Node-side
+ * mirror of the inline helpers in index.html — viewer keeps its own copies
+ * because the index.html file is meant to remain self-contained.
+ *
+ * Why EDT specifically: the mission window (April 1-10, 2026) lies entirely
+ * within EDT (no spring-forward / fall-back boundary). For Artemis II all
+ * times happen to also be EDT. If you ever need to support mission events
+ * spanning a DST boundary, this module will need to change.
+ */
+
+'use strict';
+
+const MS_PER_HOUR = 3600 * 1000;
+const EDT_OFFSET_MS = -4 * MS_PER_HOUR;
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/**
+ * Parse a "YYYY-MM-DD HH:MM:SS" EDT string into Unix milliseconds.
+ *
+ * @param {string} s
+ * @returns {number} milliseconds since epoch
+ */
+function edt(s) {
+  return new Date(s.replace(' ', 'T') + '-04:00').getTime();
+}
+
+/**
+ * Decompose a Unix-ms timestamp into EDT date/time parts.
+ *
+ * Trick: shift the timestamp by -4h, then read the UTC accessors of the
+ * resulting Date. The UTC values are now the EDT-local values. Avoids the
+ * browser-dependent behaviour of Date.toLocaleString.
+ *
+ * @param {number} ts
+ * @returns {{mon: string, day: string, dayNum: number, hr24: number,
+ *           hr: number, min: string, sec: string, ampm: string}}
+ */
+function edtParts(ts) {
+  const d = new Date(ts + EDT_OFFSET_MS);
+  return {
+    mon:    MONTHS[d.getUTCMonth()],
+    day:    String(d.getUTCDate()).padStart(2, '0'),
+    dayNum: d.getUTCDate(),
+    hr24:   d.getUTCHours(),
+    hr:     d.getUTCHours() % 12 || 12,
+    min:    String(d.getUTCMinutes()).padStart(2, '0'),
+    sec:    String(d.getUTCSeconds()).padStart(2, '0'),
+    ampm:   d.getUTCHours() < 12 ? 'AM' : 'PM'
+  };
+}
+
+/**
+ * Format an EDT timestamp as "Apr 01, 6:35:25 PM".
+ */
+function formatTime(ts) {
+  const p = edtParts(ts);
+  return `${p.mon} ${p.day}, ${p.hr}:${p.min}:${p.sec} ${p.ampm}`;
+}
+
+/**
+ * Format an EDT timestamp as "Apr 1, 6:35 PM".
+ */
+function formatTimeShort(ts) {
+  const p = edtParts(ts);
+  return `${p.mon} ${p.dayNum}, ${p.hr}:${p.min} ${p.ampm}`;
+}
+
+/**
+ * Convert a Unix-ms timestamp into the "YYYY-MM-DD HH:MM:SS" EDT string
+ * format used inside photos.js.
+ *
+ * @param {number} ts
+ * @returns {string}
+ */
+function toPhotosTime(ts) {
+  const d = new Date(ts + EDT_OFFSET_MS);
+  const y = d.getUTCFullYear();
+  const mo = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  const hr = String(d.getUTCHours()).padStart(2, '0');
+  const mi = String(d.getUTCMinutes()).padStart(2, '0');
+  const se = String(d.getUTCSeconds()).padStart(2, '0');
+  return `${y}-${mo}-${day} ${hr}:${mi}:${se}`;
+}
+
+/**
+ * Produce an ISO-8601 timestamp string in EDT (UTC-04:00).
+ * Used for the `addedAt` schema field on photo entries.
+ *
+ * @param {Date} [d] — defaults to "now"
+ * @returns {string}
+ */
+function isoEdt(d) {
+  d = d || new Date();
+  const shifted = new Date(d.getTime() + EDT_OFFSET_MS);
+  const y = shifted.getUTCFullYear();
+  const mo = String(shifted.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(shifted.getUTCDate()).padStart(2, '0');
+  const hr = String(shifted.getUTCHours()).padStart(2, '0');
+  const mi = String(shifted.getUTCMinutes()).padStart(2, '0');
+  const se = String(shifted.getUTCSeconds()).padStart(2, '0');
+  return `${y}-${mo}-${day}T${hr}:${mi}:${se}-04:00`;
+}
+
+module.exports = {
+  edt,
+  edtParts,
+  formatTime,
+  formatTimeShort,
+  toPhotosTime,
+  isoEdt,
+};

--- a/tools/import/shared/env.js
+++ b/tools/import/shared/env.js
@@ -1,0 +1,89 @@
+/**
+ * Tiny .env-style credential loader for the acquisition pipeline.
+ *
+ * We don't want secrets in tracked files (this is exactly what got the
+ * legacy fetch-flickr-descriptions.js key revoked), so credentials live
+ * in `tools/import/.env.local` which is gitignored via the `*.local`
+ * pattern in .gitignore.
+ *
+ * File format (one assignment per line, very small subset of .env spec):
+ *
+ *   # comments start with #
+ *   KEY=value
+ *   QUOTED="value with spaces"
+ *
+ * Lookup order: process.env first, then .env.local.
+ *
+ * Returns null if the credential isn't found anywhere — callers should
+ * decide whether that's a hard error or a "skip this adapter" condition.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_ENV_PATH = path.join(__dirname, '..', '.env.local');
+
+let cachedEnv = null;
+let cachedPath = null;
+
+function parseEnvFile(envPath) {
+  if (!fs.existsSync(envPath)) return {};
+  const raw = fs.readFileSync(envPath, 'utf8');
+  const out = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let val = trimmed.slice(eq + 1).trim();
+    // Strip matched surrounding quotes
+    if (val.length >= 2 &&
+        ((val.startsWith('"') && val.endsWith('"')) ||
+         (val.startsWith("'") && val.endsWith("'")))) {
+      val = val.slice(1, -1);
+    }
+    out[key] = val;
+  }
+  return out;
+}
+
+function loadEnv(envPath) {
+  envPath = envPath || DEFAULT_ENV_PATH;
+  if (cachedEnv && cachedPath === envPath) return cachedEnv;
+  cachedEnv = parseEnvFile(envPath);
+  cachedPath = envPath;
+  return cachedEnv;
+}
+
+/**
+ * Get a credential by name. Process env takes priority over the .env.local
+ * file. Returns null if absent.
+ *
+ * @param {string} name
+ * @param {string} [envPath]  optional override for .env.local location
+ * @returns {string|null}
+ */
+function getCredential(name, envPath) {
+  if (process.env[name]) return process.env[name];
+  const env = loadEnv(envPath);
+  return env[name] || null;
+}
+
+/**
+ * Get a credential or throw if missing. Useful for adapters that can't
+ * function at all without their key.
+ */
+function requireCredential(name, envPath) {
+  const v = getCredential(name, envPath);
+  if (!v) {
+    throw new Error(
+      `Missing required credential ${name}. Add it to tools/import/.env.local or set the env var.`
+    );
+  }
+  return v;
+}
+
+module.exports = { getCredential, requireCredential, loadEnv };

--- a/tools/import/shared/ids.js
+++ b/tools/import/shared/ids.js
@@ -1,0 +1,91 @@
+/**
+ * Stable-ID extraction for Artemis Timeline photo filenames.
+ *
+ * Mirrors getFlickrId() from index.html. The viewer keeps its own inline
+ * copy because index.html is meant to remain a single self-contained file
+ * with no build step; this Node-side module is for tools that need the
+ * same logic outside the browser (sync.js, migrate.js, server.js).
+ *
+ * Filename patterns we recognize:
+ *   55182417729_3e6cb18922_o.jpg     Flickr (11-digit ID)
+ *   9608627.jpg                       DVIDS / Navy (7-digit ID)
+ *   art002e014256~large.jpg           NASA art-series
+ *   KSC-20260401-PH-KLS01_0013.jpg    Kennedy Space Center
+ *   NHQ202604100032.jpg               NASA Headquarters photographer
+ *   ig-some-slug.mp4                  Instagram embed
+ *   yt-some-slug.jpg                  YouTube embed
+ */
+
+'use strict';
+
+/**
+ * Extract a stable ID from a photo filename.
+ * Returns null only if the filename has no recognizable basename.
+ *
+ * @param {string} filename
+ * @returns {string|null}
+ */
+function getFlickrId(filename) {
+  if (!filename) return null;
+
+  // Flickr: 11 digits followed by _ or -
+  const m = filename.match(/^(\d{11})[_-]/);
+  if (m) return m[1];
+
+  // DVIDS / Navy: 7 digits then ".jpg"
+  const dv = filename.match(/^(\d{7})\.jpg$/);
+  if (dv) return dv[1];
+
+  // NASA art-series: art<digits>e<digits>
+  const n = filename.match(/^(art\d+e\d+)/);
+  if (n) return n[1];
+
+  // Instagram embed
+  const ig = filename.match(/^(ig-[a-z0-9-]+)\./);
+  if (ig) return ig[1];
+
+  // YouTube embed
+  const yt = filename.match(/^(yt-[a-z0-9-]+)\./);
+  if (yt) return yt[1];
+
+  // Fallback: strip ~large/~orig suffix and extension; use whatever's left
+  const base = filename
+    .replace(/~(large|orig)/, '')
+    .replace(/\.[^.]+$/, '');
+  return base || null;
+}
+
+/**
+ * Slugify any string into a URL-safe lowercase form with dashes.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+function slugify(s) {
+  return String(s)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}
+
+/**
+ * Produce the URL-hash slug for a photo entry.
+ *
+ * The browser viewer uses this for deep linking — each photo gets a hash
+ * like `#christina-koch-smiles-before-launch` so a single photo can be
+ * shared or bookmarked. The viewer's inline version reads a global
+ * PHOTO_TITLES map; here we take the title explicitly.
+ *
+ * Falls back through: title → flickr/source ID → filename without extension.
+ *
+ * @param {{ file: string, title?: string }} entry
+ * @returns {string}
+ */
+function photoSlug({ file, title }) {
+  if (title) return slugify(title);
+  const fid = getFlickrId(file);
+  if (fid) return fid;
+  return file.replace(/\.[^.]+$/, '');
+}
+
+module.exports = { getFlickrId, slugify, photoSlug };

--- a/tools/import/shared/photos-io.js
+++ b/tools/import/shared/photos-io.js
@@ -1,0 +1,106 @@
+/**
+ * Read and write the canonical `photos.js` data file.
+ *
+ * `photos.js` is a tiny wrapper around a JSON-shaped object:
+ *
+ *     const PHOTO_DATA = { "photos": [...], "audio": [...] };
+ *
+ * Hank's admin.html emits this via `JSON.stringify(data, null, 2)` and
+ * prepends the `const ...=` wrapper, so the body is reliably clean JSON.
+ * We rely on that assumption when parsing here. If anyone hand-edits the
+ * file with JS-specific syntax (comments, trailing commas, single quotes),
+ * this loader will fail; the caller should propagate that error clearly
+ * rather than silently fall back.
+ *
+ * Writes are atomic: serialize → write to `<path>.tmp` → fsync → rename.
+ * On Windows the rename is also atomic when the target exists, but only
+ * if the temp file is on the same volume — which it always is since we
+ * write next to the original.
+ */
+
+'use strict';
+
+const fs = require('fs/promises');
+const path = require('path');
+
+const WRAPPER_PREFIX = 'const PHOTO_DATA = ';
+const WRAPPER_SUFFIX = ';\n';
+
+/**
+ * Read `photos.js` from disk and return the parsed PHOTO_DATA object.
+ *
+ * @param {string} photosJsPath - absolute path to photos.js
+ * @returns {Promise<{photos: object[], audio: object[]}>}
+ */
+async function readPhotosJs(photosJsPath) {
+  const raw = await fs.readFile(photosJsPath, 'utf8');
+  const trimmed = raw.trim();
+
+  if (!trimmed.startsWith('const PHOTO_DATA')) {
+    throw new Error(
+      `photos.js does not start with "const PHOTO_DATA" — got: ${trimmed.slice(0, 60)}...`
+    );
+  }
+
+  // Strip "const PHOTO_DATA = " (with or without surrounding whitespace)
+  // and the trailing semicolon. What remains should be parseable JSON.
+  const eqIdx = trimmed.indexOf('=');
+  if (eqIdx < 0) {
+    throw new Error('photos.js missing "=" after "const PHOTO_DATA"');
+  }
+  let body = trimmed.slice(eqIdx + 1).trim();
+  if (body.endsWith(';')) body = body.slice(0, -1).trim();
+
+  try {
+    return JSON.parse(body);
+  } catch (err) {
+    throw new Error(`photos.js body is not valid JSON: ${err.message}`);
+  }
+}
+
+/**
+ * Serialize a PHOTO_DATA object and write it to disk atomically.
+ *
+ * @param {string} photosJsPath - absolute path to photos.js
+ * @param {object} data - the PHOTO_DATA object to write
+ */
+async function writePhotosJs(photosJsPath, data) {
+  const json = JSON.stringify(data, null, 2);
+  const content = WRAPPER_PREFIX + json + WRAPPER_SUFFIX;
+
+  const tmpPath = photosJsPath + '.tmp';
+  // Write + fsync to make the durability/atomicity story honest on crash.
+  const fh = await fs.open(tmpPath, 'w');
+  try {
+    await fh.writeFile(content, 'utf8');
+    await fh.sync();
+  } finally {
+    await fh.close();
+  }
+  // rename() is atomic on POSIX and on Windows when src+dst are on the
+  // same volume (which they always are here).
+  await fs.rename(tmpPath, photosJsPath);
+}
+
+/**
+ * Append photo entries to PHOTO_DATA and write the result. Convenience
+ * wrapper around readPhotosJs + writePhotosJs.
+ *
+ * Caller is responsible for ensuring entries are unique (no dedup here).
+ *
+ * @param {string} photosJsPath
+ * @param {object[]} newPhotos
+ * @returns {Promise<number>} new total photo count
+ */
+async function appendPhotos(photosJsPath, newPhotos) {
+  const data = await readPhotosJs(photosJsPath);
+  data.photos = data.photos.concat(newPhotos);
+  await writePhotosJs(photosJsPath, data);
+  return data.photos.length;
+}
+
+module.exports = {
+  readPhotosJs,
+  writePhotosJs,
+  appendPhotos,
+};

--- a/tools/import/sources/base.js
+++ b/tools/import/sources/base.js
@@ -1,0 +1,82 @@
+/**
+ * Source adapter interface.
+ *
+ * Every file in `tools/import/sources/` (other than this one) must export
+ * a `discover` function with the signature documented below, plus a `NAME`
+ * string identifying the adapter.
+ *
+ * This file is not imported anywhere — it exists as documentation and as a
+ * place to define the candidate shape used by all adapters.
+ */
+
+'use strict';
+
+/**
+ * @typedef {Object} Candidate
+ *
+ * The normalized record every adapter produces. The orchestrator
+ * (sync.js) dedups, classifies, and writes these to inbox.json.
+ *
+ * @property {string}   source           - adapter NAME (e.g. "nasa_library")
+ * @property {string}   source_id        - stable ID at the source
+ * @property {string}   source_url       - human-friendly URL at the source
+ * @property {string}   image_url        - direct URL to the full-resolution image
+ *                                          (used at promote time as the source
+ *                                          for the local web/ copy)
+ * @property {string}   thumb_url        - direct URL to a small thumbnail
+ *                                          (used by the admin Pending tab to
+ *                                          render review thumbnails)
+ * @property {string}   title            - human-readable title
+ * @property {string}   description      - longer-form description
+ * @property {string}   photographer     - photographer credit; "NASA" or "" if unknown
+ * @property {string}   location         - free-text facility / city; "" if unknown
+ * @property {string}   center           - NASA center code if applicable:
+ *                                          KSC / JSC / MSFC / SSC / MAF / HQ /
+ *                                          GSFC / GRC / LARC / AFRC / ARC.
+ *                                          Empty string for in-flight, recovery,
+ *                                          or non-NASA locations.
+ * @property {string}   camera           - camera model (typically "" for non-EXIF sources)
+ * @property {string}   settings         - exposure settings (typically "" for non-EXIF sources)
+ * @property {string}   taken_at         - "YYYY-MM-DD HH:MM:SS" in EDT, best-available
+ *                                          timestamp from the source
+ * @property {string[]} tags             - keyword tags from the source
+ * @property {boolean}  spacecraft       - taken from inside the spacecraft?
+ * @property {boolean}  video            - is this a video?
+ * @property {string}   source_default_era - adapter's baseline guess: one of
+ *                                            "pre-flight-hardware", "pre-flight-training",
+ *                                            "mission", "post-mission", or "unknown"
+ */
+
+/**
+ * @typedef {Object} DiscoverOptions
+ *
+ * @property {Set<string>} [seenIds]      - source_ids the orchestrator
+ *                                           already knows about; adapter
+ *                                           may use this for early-stop
+ *                                           heuristics
+ * @property {boolean}     [fullRescan]   - if true, walk full result space
+ *                                           instead of stopping at the first
+ *                                           run of already-seen items
+ * @property {number}      [limit]        - hard cap on candidates returned
+ *                                           across all queries in this run
+ *                                           (the kill switch)
+ * @property {string[]}    [queries]      - override the adapter's default
+ *                                           query list
+ */
+
+/**
+ * @typedef {Object} DiscoverResult
+ *
+ * @property {Candidate[]} candidates
+ * @property {Object}      [debugInfo]    - opaque per-run info for logging
+ */
+
+/**
+ * @typedef {Object} Adapter
+ *
+ * @property {string} NAME                              - adapter identifier
+ * @property {string} [SOURCE_DEFAULT_ERA]              - default era for this adapter's output
+ * @property {(opts: DiscoverOptions) => Promise<DiscoverResult>} discover
+ */
+
+module.exports = {};   // documentation-only module

--- a/tools/import/sources/flickr.js
+++ b/tools/import/sources/flickr.js
@@ -1,0 +1,452 @@
+#!/usr/bin/env node
+/**
+ * Flickr adapter for the acquisition pipeline.
+ *
+ * Pulls Artemis II imagery from NASA-run Flickr photostreams via the
+ * Flickr REST API (https://api.flickr.com/services/rest/).
+ *
+ * Credential: FLICKR_API_KEY in tools/import/.env.local (gitignored).
+ * To get a key: https://www.flickr.com/services/apps/create/apply/
+ *
+ * Source coverage (default):
+ *
+ *   1. NASA Johnson's curated "Artemis II" photoset (id 72177720307234654).
+ *      ~407 photos as of May 2026, very low noise — these are NASA's own
+ *      Artemis II selection. Most-efficient starting point.
+ *
+ *   2. NASA HQ Photo's photostream, narrowed to "Artemis II" via search.
+ *      Pulls launch/recovery press photos that didn't land in the curated
+ *      album. Higher recall, slightly more dedup against Hank's data.
+ *
+ * Each source produces candidates with a distinct `source` label
+ * (flickr_nasajohnson_artemis2, flickr_nasahqphoto, …) so the admin
+ * Pending tab can filter by which photostream a candidate came from.
+ *
+ * Standalone test mode:
+ *   node tools/import/sources/flickr.js --limit 5
+ *   node tools/import/sources/flickr.js --source artemis2 --limit 5 --json
+ */
+
+'use strict';
+
+const path = require('path');
+const { requireCredential } = require('../shared/env');
+
+const NAME = 'flickr';
+const SOURCE_DEFAULT_ERA = 'unknown';
+
+const API_BASE = 'https://api.flickr.com/services/rest/';
+const PAGE_SIZE = 100;
+const DELAY_MS = 200;
+const STOP_AFTER_CONSECUTIVE_SEEN = 10;
+
+// Comma-separated list of optional fields to ask Flickr to return per
+// photo. Without these the basic listing returns id/owner/title only.
+const EXTRAS = 'description,date_taken,owner_name,tags,url_l,url_s,url_o';
+
+// Per-source configurations. Each one produces candidates labeled with
+// its own source string and (when known) a baseline NASA center.
+//
+// NSIDs verified via flickr.urls.lookupUser. Don't trust the URL alias —
+// e.g. "nasa2explore" is the alias for NASA Johnson, NSID 29988733@N04,
+// and the URL alias "nasakennedy" maps to 108488366@N07.
+const DEFAULT_SOURCES = [
+  // NASA Johnson's curated Artemis II album. Cleanest possible starting set.
+  // The photoset ID is globally unique so we don't need a user_id here.
+  {
+    key: 'artemis2',
+    kind: 'photoset',
+    source_label: 'flickr_nasajohnson_artemis2',
+    photoset_id: '72177720307234654',
+    default_center: 'JSC',
+    note: 'NASA Johnson\'s curated Artemis II photoset',
+  },
+  // NASA HQ Photo's full photostream, narrowed by free-text search.
+  // Mix of launch press, walkout, splashdown, and HQ briefings.
+  {
+    key: 'nasahq',
+    kind: 'user_search',
+    source_label: 'flickr_nasahqphoto',
+    user_id: '35067687@N04',                 // NASA HQ Photo
+    text: 'Artemis II',
+    default_center: 'HQ',
+    note: 'NASA HQ Photo photostream, text="Artemis II"',
+  },
+  // NASA Kennedy photostream — launch operations, pad ops, integration.
+  // Primary source for KSC-side mission-week imagery.
+  {
+    key: 'kennedy',
+    kind: 'user_search',
+    source_label: 'flickr_nasakennedy',
+    user_id: '108488366@N07',                // NASAKennedy
+    text: 'Artemis II',
+    default_center: 'KSC',
+    note: 'NASA Kennedy photostream, text="Artemis II"',
+  },
+  // NASA Marshall photostream — SLS hardware, engine tests, core stage.
+  // Primary source for pre-flight-hardware imagery (the era bucket we have
+  // zero of in canon today).
+  {
+    key: 'marshall',
+    kind: 'user_search',
+    source_label: 'flickr_nasamarshall',
+    user_id: '28634332@N05',                 // NASA's Marshall Space Flight Center
+    text: 'Artemis II',
+    default_center: 'MSFC',
+    note: 'NASA Marshall photostream, text="Artemis II"',
+  },
+];
+
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+// Word-boundary regex for Artemis II: matches "Artemis II", "Artemis II.",
+// "Artemis II crew", etc. — does NOT match "Artemis III" or "Artemis IIII"
+// because there's no word boundary between consecutive 'I' characters.
+//
+// Flickr's `text` search parameter does substring matching, so a query for
+// "Artemis II" returns hits where the literal substring appears anywhere in
+// title / description / tags — including within "Artemis III". This regex
+// catches the false positives at the adapter level so the orchestrator
+// downstream never sees them.
+const ARTEMIS_II_RE = /\bArtemis\s+II\b/i;
+
+// Other Artemis missions whose presence in the *title* disqualifies a
+// candidate regardless of whether the description happens to mention
+// Artemis II in passing. Titles are authoritative: the post creator is
+// telling you what the post is about.
+const OTHER_ARTEMIS_TITLE_RE = /\bArtemis\s+(I|III|IV|V|VI|VII|VIII|IX|X|3|4|5)\b/i;
+
+/**
+ * Return true if the candidate has at least one strong "Artemis II"
+ * signal AND its title doesn't explicitly call out a different Artemis
+ * mission. Used to reject content that slipped through Flickr's
+ * substring-based search.
+ */
+function mentionsArtemisII(candidate) {
+  // First: if the title explicitly says "Artemis III" / "Artemis I" / etc.,
+  // reject regardless of any Artemis II mention in the description.
+  if (OTHER_ARTEMIS_TITLE_RE.test(candidate.title || '')) {
+    // BUT — if the title also explicitly says Artemis II (e.g. "Artemis II
+    // and Artemis III comparison"), keep the post and let the reviewer
+    // decide.
+    if (!ARTEMIS_II_RE.test(candidate.title || '')) return false;
+  }
+
+  // Otherwise: any Artemis II signal in title, description, or tags wins.
+  if (ARTEMIS_II_RE.test(candidate.title || '')) return true;
+  if (ARTEMIS_II_RE.test(candidate.description || '')) return true;
+  if (Array.isArray(candidate.tags)) {
+    for (const t of candidate.tags) {
+      if (ARTEMIS_II_RE.test(t)) return true;
+      // Flickr machine-tag conventions: "artemis2" / "artemisii".
+      if (/^artemis(2|ii)$/i.test(t)) return true;
+    }
+  }
+  return false;
+}
+
+// -------------------------------------------------------------------------
+// API wrappers
+// -------------------------------------------------------------------------
+
+async function flickrApi(apiKey, method, params) {
+  const url = new URL(API_BASE);
+  url.searchParams.set('method', method);
+  url.searchParams.set('api_key', apiKey);
+  url.searchParams.set('format', 'json');
+  url.searchParams.set('nojsoncallback', '1');
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+
+  const res = await fetch(url.toString());
+  if (!res.ok) {
+    throw new Error(`Flickr ${method} HTTP ${res.status} ${res.statusText}`);
+  }
+  const json = await res.json();
+  if (json.stat !== 'ok') {
+    throw new Error(`Flickr ${method} failed: ${json.message || JSON.stringify(json)}`);
+  }
+  return json;
+}
+
+async function fetchPhotosetPage(apiKey, photosetId, page) {
+  const json = await flickrApi(apiKey, 'flickr.photosets.getPhotos', {
+    photoset_id: photosetId,
+    per_page: String(PAGE_SIZE),
+    page: String(page),
+    extras: EXTRAS,
+  });
+  return {
+    photos: (json.photoset && json.photoset.photo) || [],
+    pages: (json.photoset && json.photoset.pages) || 1,
+    total: parseInt((json.photoset && json.photoset.total) || '0', 10),
+  };
+}
+
+async function fetchUserSearchPage(apiKey, userId, text, page) {
+  const json = await flickrApi(apiKey, 'flickr.photos.search', {
+    user_id: userId,
+    text: text,
+    per_page: String(PAGE_SIZE),
+    page: String(page),
+    extras: EXTRAS,
+  });
+  return {
+    photos: (json.photos && json.photos.photo) || [],
+    pages: (json.photos && json.photos.pages) || 1,
+    total: parseInt((json.photos && json.photos.total) || '0', 10),
+  };
+}
+
+// -------------------------------------------------------------------------
+// Normalization
+// -------------------------------------------------------------------------
+
+/**
+ * Strip the HTML Flickr embeds in descriptions and unescape the common
+ * entities. Flickr passes descriptions back as HTML even via the JSON API.
+ */
+function stripHtml(s) {
+  if (!s) return '';
+  return String(s)
+    .replace(/<[^>]*>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .trim();
+}
+
+/**
+ * Map the photostream owner display name to a photographer credit. NASA
+ * accounts don't credit individual photographers in the ownername field,
+ * so we default to "NASA" and let normalize.js polish further when sync
+ * runs.
+ */
+function inferPhotographer(ownername) {
+  if (!ownername) return 'NASA';
+  // For known NASA accounts: don't attribute the institutional name as
+  // photographer. The reviewer can fill in a specific name during admin.
+  if (/^(NASA Johnson|NASA HQ|NASA Kennedy|NASA Marshall|NASA Goddard|nasahqphoto|nasa2explore|NASA Photo One)$/i.test(ownername)) {
+    return 'NASA';
+  }
+  return ownername;
+}
+
+/**
+ * Convert a Flickr photo record into the Candidate shape.
+ */
+function normalizeItem(item, sourceCfg) {
+  const id = String(item.id || '');
+  const description = stripHtml(item.description && item.description._content);
+  const tags = item.tags ? String(item.tags).split(/\s+/).filter(Boolean) : [];
+
+  // Flickr's "owner" field is the photographer's NSID; "ownername" is
+  // the display name. For the source URL we'd prefer the path-alias if
+  // known, but the NSID works fine in Flickr URLs too.
+  const ownerSlug = item.owner || '';
+  const sourceUrl = id && ownerSlug
+      ? `https://www.flickr.com/photos/${ownerSlug}/${id}/`
+      : `https://www.flickr.com/photo.gne?id=${id}`;
+
+  return {
+    source: sourceCfg.source_label,
+    source_id: id,
+    source_url: sourceUrl,
+    image_url: item.url_l || item.url_o || '',
+    thumb_url: item.url_s || item.url_l || '',
+    title: (item.title || '').trim(),
+    description,
+    photographer: inferPhotographer(item.ownername),
+    location: '',
+    center: sourceCfg.default_center || '',
+    camera: '',
+    settings: '',
+    // Flickr already returns "YYYY-MM-DD HH:MM:SS" in datetaken (local
+    // photographer time, which for NASA photos is overwhelmingly EDT or
+    // close enough — reviewer can refine if a specific photo has drifted).
+    taken_at: item.datetaken || '',
+    tags,
+    spacecraft: false,
+    video: false,
+    source_default_era: SOURCE_DEFAULT_ERA,
+  };
+}
+
+// -------------------------------------------------------------------------
+// Discover
+// -------------------------------------------------------------------------
+
+async function discover(opts = {}) {
+  const seenIds = opts.seenIds || new Set();
+  const fullRescan = !!opts.fullRescan;
+  const limit = Math.max(1, opts.limit | 0) || 100;
+  const sources = opts.sources || DEFAULT_SOURCES;
+
+  const apiKey = requireCredential('FLICKR_API_KEY');
+
+  const candidates = [];
+  const debugInfo = { perSource: {} };
+  let accumulatedBeforeSource = 0;
+
+  for (const src of sources) {
+    if (candidates.length >= limit) break;
+
+    let page = 1;
+    let totalPages = null;
+    let total = null;
+    let pagesFetched = 0;
+    let consecutiveSeen = 0;
+    let stoppedEarly = false;
+    let reachedLimit = false;
+    let falsePositivesFiltered = 0;
+
+    while (candidates.length < limit) {
+      let result;
+      try {
+        if (src.kind === 'photoset')         result = await fetchPhotosetPage(apiKey, src.photoset_id, page);
+        else if (src.kind === 'user_search') result = await fetchUserSearchPage(apiKey, src.user_id, src.text, page);
+        else throw new Error(`unknown flickr source kind: ${src.kind}`);
+      } catch (err) {
+        // Per-source errors shouldn't kill the whole sync. Record and continue.
+        debugInfo.perSource[src.source_label] = { error: err.message, page, pagesFetched };
+        break;
+      }
+
+      if (totalPages === null) { totalPages = result.pages; total = result.total; }
+      pagesFetched++;
+
+      if (result.photos.length === 0) break;
+
+      for (const photo of result.photos) {
+        const cand = normalizeItem(photo, src);
+        if (!cand.source_id) continue;
+
+        // For text-search sources, reject anything that slipped through
+        // Flickr's substring match without actually being Artemis II.
+        // Album/photoset sources are curated upstream, so we trust them.
+        if (src.kind === 'user_search' && !mentionsArtemisII(cand)) {
+          falsePositivesFiltered++;
+          continue;
+        }
+
+        if (seenIds.has(cand.source_id)) {
+          consecutiveSeen++;
+          if (!fullRescan && consecutiveSeen >= STOP_AFTER_CONSECUTIVE_SEEN) {
+            stoppedEarly = true;
+            break;
+          }
+          continue;
+        }
+        consecutiveSeen = 0;
+        candidates.push(cand);
+        seenIds.add(cand.source_id);
+        if (candidates.length >= limit) {
+          reachedLimit = true;
+          break;
+        }
+      }
+
+      if (stoppedEarly || reachedLimit) break;
+      if (page >= totalPages) break;
+      page++;
+      await sleep(DELAY_MS);
+    }
+
+    debugInfo.perSource[src.source_label] = {
+      kind: src.kind,
+      totalPages,
+      total,
+      pagesFetched,
+      addedThisSource: candidates.length - accumulatedBeforeSource,
+      falsePositivesFiltered,
+      stoppedEarly,
+      reachedLimit,
+    };
+    accumulatedBeforeSource = candidates.length;
+  }
+
+  return { candidates, debugInfo };
+}
+
+// -------------------------------------------------------------------------
+// Standalone test mode
+// -------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = { limit: 5, source: null, fullRescan: false, json: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--limit')         args.limit = parseInt(argv[++i], 10) || 5;
+    else if (a === '--source')   args.source = argv[++i];
+    else if (a === '--full-rescan') args.fullRescan = true;
+    else if (a === '--json')     args.json = true;
+    else if (a === '-h' || a === '--help') args.help = true;
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node ${path.basename(__filename)} [options]
+
+Options:
+  --limit N            Max candidates total (default 5)
+  --source KEY         Limit to one configured source by its key:
+                         ${DEFAULT_SOURCES.map(s => s.key).join(', ')}
+  --full-rescan        Don't stop at consecutive-seen
+  --json               Output raw JSON
+  -h, --help           Show this help
+
+Requires FLICKR_API_KEY in tools/import/.env.local (or env var).`);
+}
+
+async function standalone() {
+  const args = parseArgs(process.argv);
+  if (args.help) { printHelp(); return; }
+
+  const sources = args.source
+      ? DEFAULT_SOURCES.filter(s => s.key === args.source)
+      : DEFAULT_SOURCES;
+  if (args.source && sources.length === 0) {
+    throw new Error(`Unknown --source "${args.source}". Known: ${DEFAULT_SOURCES.map(s => s.key).join(', ')}`);
+  }
+
+  console.error(`[flickr] discovering from sources: ${sources.map(s => s.source_label).join(', ')}, limit=${args.limit}`);
+  const result = await discover({ limit: args.limit, fullRescan: args.fullRescan, sources });
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log('');
+  console.log(`=== ${result.candidates.length} candidates ===`);
+  for (const c of result.candidates) {
+    console.log('');
+    console.log(`  ID:     ${c.source_id}`);
+    console.log(`  Title:  ${c.title}`);
+    console.log(`  Taken:  ${c.taken_at || '(unknown)'}`);
+    console.log(`  Source: ${c.source}`);
+    console.log(`  Center: ${c.center || '(none)'}`);
+    console.log(`  By:     ${c.photographer}`);
+    console.log(`  Tags:   ${c.tags.slice(0, 5).join(', ')}${c.tags.length > 5 ? '...' : ''}`);
+    console.log(`  Image:  ${c.image_url || '(no URL)'}`);
+    if (c.description) {
+      const d = c.description.replace(/\s+/g, ' ').trim();
+      console.log(`  Desc:   ${d.slice(0, 120)}${d.length > 120 ? '...' : ''}`);
+    }
+  }
+  console.log('');
+  console.log('=== debug ===');
+  console.log(JSON.stringify(result.debugInfo, null, 2));
+}
+
+if (require.main === module) {
+  standalone().catch(err => {
+    console.error('ERROR:', err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { NAME, SOURCE_DEFAULT_ERA, DEFAULT_SOURCES, discover };

--- a/tools/import/sources/nasa-library.js
+++ b/tools/import/sources/nasa-library.js
@@ -1,0 +1,394 @@
+#!/usr/bin/env node
+/**
+ * NASA Image and Video Library adapter.
+ *
+ * Queries https://images-api.nasa.gov/search for Artemis II imagery and
+ * returns normalized candidate records.
+ *
+ * No API key required for read. Rate-limit risk is low at our scale but
+ * we courtesy-throttle between page fetches (DELAY_MS) anyway.
+ *
+ * The API's search results already include direct URLs to each asset's
+ * thumb/small/medium/large/orig versions in items[].links[], so no second
+ * "asset endpoint" round-trip is needed during discovery.
+ *
+ * Standalone test mode:
+ *   node tools/import/sources/nasa-library.js --limit 5
+ *   node tools/import/sources/nasa-library.js --query "Artemis II crew training" --limit 10
+ *   node tools/import/sources/nasa-library.js --query "SLS Block 1" --limit 10 --json
+ *
+ * The standalone mode never writes to inbox/state and never calls a network
+ * downloader — it's strictly for inspecting what the API returns and what
+ * the adapter normalizes it into.
+ */
+
+'use strict';
+
+const path = require('path');
+const { toPhotosTime } = require('../shared/dates');
+
+const NAME = 'nasa_library';
+const SOURCE_DEFAULT_ERA = 'unknown';   // NASA Library results are mixed-content;
+                                        // let the per-image classifier decide.
+
+const API_BASE = 'https://images-api.nasa.gov';
+const DELAY_MS = 200;                   // courtesy delay between pages
+const PAGE_SIZE = 100;                  // NASA API max page size
+const STOP_AFTER_CONSECUTIVE_SEEN = 10; // incremental-run early-stop threshold
+
+// Default query set. Override via the `queries` option in DiscoverOptions
+// or via --query flag in standalone test mode. Order matters only for
+// ordering of the consolidated results; everything is deduped at the end.
+const DEFAULT_QUERIES = [
+  'Artemis II',
+  'Artemis II crew',
+  'Artemis II SLS',
+  'Artemis II Orion',
+  'Artemis II training',
+];
+
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+/**
+ * Fetch one page of search results. Returns { items, total_hits }.
+ */
+async function searchPage(query, page) {
+  const url = new URL(API_BASE + '/search');
+  url.searchParams.set('q', query);
+  url.searchParams.set('media_type', 'image');
+  url.searchParams.set('page', String(page));
+  url.searchParams.set('page_size', String(PAGE_SIZE));
+
+  const res = await fetch(url.toString());
+  if (!res.ok) {
+    throw new Error(`NASA Library API ${res.status}: ${res.statusText} (${url})`);
+  }
+  const json = await res.json();
+  const c = json.collection || {};
+  return {
+    items: c.items || [],
+    total_hits: (c.metadata && c.metadata.total_hits) || 0,
+  };
+}
+
+/**
+ * Categorize a link by its size suffix in the URL. NASA Image Library
+ * URLs end with one of ~thumb / ~small / ~medium / ~large / ~orig before
+ * the extension. We use these to pick the right size for each purpose:
+ *
+ *   - Full-quality download: prefer ~large (typically 1242x1920, ~180KB —
+ *     fine for the timeline viewer; saves us a heavy ~orig download + an
+ *     ImageMagick resize round-trip).
+ *   - Thumbnail for admin UI: prefer ~small (414x640, ~21KB).
+ *
+ * Falls back gracefully to whatever sizes the asset happens to have.
+ */
+function sizeOfLink(href) {
+  if (typeof href !== 'string') return null;
+  const m = href.match(/~(thumb|small|medium|large|orig)\.[a-z0-9]+($|\?)/i);
+  return m ? m[1].toLowerCase() : null;
+}
+
+function pickByPreference(links, preferences) {
+  if (!Array.isArray(links)) return null;
+  const bySize = {};
+  for (const l of links) {
+    if (!l || !l.href || l.render !== 'image') continue;
+    const size = sizeOfLink(l.href);
+    if (size) bySize[size] = l.href;
+  }
+  for (const want of preferences) {
+    if (bySize[want]) return bySize[want];
+  }
+  // Last-resort: any image link we found
+  return Object.values(bySize)[0] || null;
+}
+
+function pickImageUrl(links) {
+  // For promotion: target ~1200-1600px wide. "large" is the sweet spot —
+  // smaller than orig but already web-sized, so we can use it as-is.
+  return pickByPreference(links, ['large', 'medium', 'orig', 'small', 'thumb']);
+}
+
+function pickThumbUrl(links) {
+  // For admin Pending tab: small is plenty.
+  return pickByPreference(links, ['small', 'thumb', 'medium', 'large']);
+}
+
+/**
+ * Convert NASA's "YYYY-MM-DDTHH:MM:SSZ" (UTC) to our EDT string format.
+ * If parsing fails, returns an empty string and lets the reviewer fill it
+ * in manually rather than guessing.
+ */
+function nasaDateToEdt(dateCreated) {
+  if (!dateCreated) return '';
+  const t = Date.parse(dateCreated);
+  if (Number.isNaN(t)) return '';
+  return toPhotosTime(t);
+}
+
+/**
+ * Extract the photographer credit from a NASA Library data record.
+ * The Library doesn't have a dedicated photographer field — credit
+ * appears most often in `secondary_creator` or `photographer` if at all.
+ */
+function extractPhotographer(d) {
+  // Some entries use `secondary_creator` as photographer credit.
+  if (d.secondary_creator) return String(d.secondary_creator).trim();
+  if (d.photographer)      return String(d.photographer).trim();
+  return 'NASA';
+}
+
+/**
+ * NASA center codes used by the Library API (and our internal schema).
+ * Exported so other modules (migrate, viewer) can use the same mapping.
+ */
+const CENTER_NAMES = {
+  HQ:   'NASA Headquarters',
+  KSC:  'Kennedy Space Center',
+  JSC:  'Johnson Space Center',
+  MSFC: 'Marshall Space Flight Center',
+  SSC:  'Stennis Space Center',
+  GSFC: 'Goddard Space Flight Center',
+  GRC:  'Glenn Research Center',
+  LARC: 'Langley Research Center',
+  AFRC: 'Armstrong Flight Research Center',
+  ARC:  'Ames Research Center',
+  MAF:  'Michoud Assembly Facility',
+};
+
+/**
+ * Extract a location hint from a NASA Library data record. The Library's
+ * `location` field is rarely populated; `center` is almost always present.
+ * Expand center codes to readable names.
+ */
+function extractLocation(d) {
+  if (d.location) return String(d.location).trim();
+  if (d.center && CENTER_NAMES[d.center]) return CENTER_NAMES[d.center];
+  if (d.center) return d.center;
+  return '';
+}
+
+/**
+ * Return the NASA center code (e.g. "KSC") for a data record, or "" if the
+ * record's center field is missing or unrecognized.
+ */
+function extractCenter(d) {
+  if (!d.center) return '';
+  const c = String(d.center).toUpperCase().trim();
+  return CENTER_NAMES[c] ? c : c;   // pass through unknown codes verbatim
+}
+
+/**
+ * Normalize a NASA Library `items[i]` record into the Candidate shape
+ * defined in sources/base.js.
+ */
+function normalizeItem(item) {
+  const d = (item.data && item.data[0]) || {};
+  const description = d.description || d.description_508 || '';
+  const imageUrl = pickImageUrl(item.links);
+  const thumbUrl = pickThumbUrl(item.links);
+
+  return {
+    source: NAME,
+    source_id: d.nasa_id || '',
+    source_url: d.nasa_id
+        ? `https://images.nasa.gov/details/${encodeURIComponent(d.nasa_id)}`
+        : '',
+    image_url: imageUrl || '',
+    thumb_url: thumbUrl || imageUrl || '',
+    title: (d.title || '').trim(),
+    description: description.trim(),
+    photographer: extractPhotographer(d),
+    location: extractLocation(d),
+    center: extractCenter(d),
+    camera: '',
+    settings: '',
+    taken_at: nasaDateToEdt(d.date_created),
+    tags: Array.isArray(d.keywords) ? d.keywords : [],
+    spacecraft: false,           // NASA Library doesn't tag this; reviewer
+                                  // toggles in admin if photo is from inside Orion
+    video: false,                // we filter media_type=image upstream
+    source_default_era: SOURCE_DEFAULT_ERA,
+  };
+}
+
+/**
+ * Main entrypoint. See base.js for the DiscoverOptions / DiscoverResult
+ * documentation.
+ */
+async function discover(opts = {}) {
+  const seenIds = opts.seenIds || new Set();
+  const fullRescan = !!opts.fullRescan;
+  const limit = Math.max(1, opts.limit | 0) || 100;
+  const queries = (opts.queries && opts.queries.length) ? opts.queries : DEFAULT_QUERIES;
+  const centers = (opts.centers && opts.centers.length)
+      ? new Set(opts.centers.map(c => String(c).toUpperCase()))
+      : null;
+
+  const candidates = [];
+  const debugInfo = {
+    queries: queries.slice(),
+    centersFilter: centers ? Array.from(centers) : null,
+    perQuery: {},
+    totalHitsAcrossQueries: 0,
+    filteredOutByCenter: 0,
+  };
+
+  // Track how many candidates we'd accumulated before each query started, so
+  // we can compute "addedThisQuery" no matter how the query iteration exits.
+  let accumulatedBeforeQuery = 0;
+
+  function recordQueryDebug(q, ctx) {
+    debugInfo.perQuery[q] = {
+      totalHits: ctx.totalHits,
+      pagesFetched: ctx.pagesFetched,
+      addedThisQuery: candidates.length - accumulatedBeforeQuery,
+      stoppedEarly: ctx.stoppedEarly,
+      reachedLimit: ctx.reachedLimit,
+    };
+    debugInfo.totalHitsAcrossQueries += ctx.totalHits || 0;
+    accumulatedBeforeQuery = candidates.length;
+  }
+
+  outer: for (const q of queries) {
+    let page = 1;
+    let consecutiveSeen = 0;
+    let pagesFetched = 0;
+    let totalHits = null;
+    let stoppedEarly = false;
+    let reachedLimit = false;
+
+    while (candidates.length < limit) {
+      const { items, total_hits } = await searchPage(q, page);
+      if (totalHits === null) totalHits = total_hits;
+      pagesFetched++;
+
+      if (items.length === 0) break;
+
+      for (const item of items) {
+        const cand = normalizeItem(item);
+        if (!cand.source_id) continue;          // skip malformed
+
+        if (seenIds.has(cand.source_id)) {
+          consecutiveSeen++;
+          if (!fullRescan && consecutiveSeen >= STOP_AFTER_CONSECUTIVE_SEEN) {
+            stoppedEarly = true;
+            break;
+          }
+          continue;
+        }
+        // Center filter: skip records whose center isn't in the allowed set.
+        // Records with no center field are filtered out when a centers
+        // restriction is in effect.
+        if (centers && !centers.has(cand.center)) {
+          debugInfo.filteredOutByCenter++;
+          continue;
+        }
+        consecutiveSeen = 0;
+        candidates.push(cand);
+        seenIds.add(cand.source_id);            // dedup within this run too
+        if (candidates.length >= limit) {
+          reachedLimit = true;
+          break;
+        }
+      }
+
+      if (stoppedEarly) break;
+      if (reachedLimit) break;
+
+      page++;
+      await sleep(DELAY_MS);
+    }
+
+    recordQueryDebug(q, { totalHits, pagesFetched, stoppedEarly, reachedLimit });
+    if (reachedLimit) break outer;
+  }
+
+  return { candidates, debugInfo };
+}
+
+// -------------------------------------------------------------------------
+// Standalone test mode
+// -------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = { limit: 5, query: null, fullRescan: false, json: false, centers: null };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--limit')        args.limit = parseInt(argv[++i], 10) || 5;
+    else if (a === '--query')   args.query = argv[++i];
+    else if (a === '--centers') args.centers = argv[++i].split(/[,\s]+/).filter(Boolean);
+    else if (a === '--full-rescan') args.fullRescan = true;
+    else if (a === '--json')    args.json = true;
+    else if (a === '-h' || a === '--help') args.help = true;
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node ${path.basename(__filename)} [options]
+
+Options:
+  --limit N          Max candidates to return (default 5)
+  --query "STR"      Override default query set with a single query
+  --centers LIST     Restrict to a comma-separated list of NASA center codes
+                     (e.g. --centers KSC,JSC,MSFC). Records with no recognized
+                     center are filtered out when this flag is used.
+  --full-rescan      Don't stop at consecutive-seen heuristic
+  --json             Output raw JSON (instead of human-readable summary)
+  -h, --help         Show this help
+
+The standalone mode does not write to any file. It only prints what would
+be passed to the orchestrator.`);
+}
+
+async function standalone() {
+  const args = parseArgs(process.argv);
+  if (args.help) { printHelp(); return; }
+
+  const opts = {
+    limit: args.limit,
+    fullRescan: args.fullRescan,
+    queries: args.query ? [args.query] : undefined,
+    centers: args.centers || undefined,
+  };
+
+  console.error(`[nasa_library] discovering (limit=${args.limit}, fullRescan=${args.fullRescan}, centers=${(args.centers || []).join(',') || 'any'}, queries=${(opts.queries || DEFAULT_QUERIES).join(' | ')})...`);
+  const result = await discover(opts);
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log('');
+  console.log(`=== ${result.candidates.length} candidates ===`);
+  for (const c of result.candidates) {
+    console.log('');
+    console.log(`  ID:       ${c.source_id}`);
+    console.log(`  Title:    ${c.title}`);
+    console.log(`  Taken:    ${c.taken_at || '(unknown)'}`);
+    console.log(`  Center:   ${c.center || '(none)'}`);
+    console.log(`  By:       ${c.photographer}`);
+    console.log(`  At:       ${c.location || '(unspecified)'}`);
+    console.log(`  Tags:     ${c.tags.slice(0, 5).join(', ')}${c.tags.length > 5 ? '...' : ''}`);
+    console.log(`  Image:    ${c.image_url || '(no canonical URL)'}`);
+    if (c.description) {
+      const d = c.description.replace(/\s+/g, ' ').trim();
+      console.log(`  Desc:     ${d.slice(0, 120)}${d.length > 120 ? '...' : ''}`);
+    }
+  }
+  console.log('');
+  console.log('=== debug ===');
+  console.log(JSON.stringify(result.debugInfo, null, 2));
+}
+
+if (require.main === module) {
+  standalone().catch(err => {
+    console.error('ERROR:', err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { NAME, SOURCE_DEFAULT_ERA, CENTER_NAMES, discover };

--- a/tools/import/sync.js
+++ b/tools/import/sync.js
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+/**
+ * Acquisition pipeline orchestrator.
+ *
+ * Wires the source adapters, normalizers, and classifier together:
+ *
+ *   1. Load persistent state (state.json) and existing canonical data
+ *      (photos.js) and the pending review queue (inbox.json).
+ *   2. Build a single `seenIds` Set from all four sources so we never
+ *      re-discover anything we've already processed.
+ *   3. Run each source adapter (NASA Image Library now; Flickr later)
+ *      with a hard `limit` cap.
+ *   4. For each new candidate: normalize → classify → score quality.
+ *   5. Append to inbox.json; update state.json's seen set; write a
+ *      per-run log.
+ *
+ * Downloads and image resizing are NOT done here yet — that comes in a
+ * follow-up commit. For now, candidates land in inbox.json with the
+ * source's image URL intact, and the admin Pending tab will load the
+ * thumbnail straight from the source (cheap to verify the flow works
+ * end-to-end before we commit disk to anything).
+ *
+ * Usage:
+ *   node tools/import/sync.js                          # default settings
+ *   node tools/import/sync.js --limit 20               # tight cap
+ *   node tools/import/sync.js --source nasa_library    # one adapter only
+ *   node tools/import/sync.js --query "Artemis II SLS" # one query
+ *   node tools/import/sync.js --centers MSFC,SSC       # one or more centers
+ *   node tools/import/sync.js --full-rescan            # ignore early-stop
+ *   node tools/import/sync.js --dry-run                # don't write anything
+ */
+
+'use strict';
+
+const fs = require('fs/promises');
+const path = require('path');
+
+const { readPhotosJs } = require('./shared/photos-io');
+const { isoEdt } = require('./shared/dates');
+const { normalizeCandidate } = require('./normalize');
+const { classify } = require('./classify');
+
+const nasaLibrary = require('./sources/nasa-library');
+const flickr      = require('./sources/flickr');
+
+const REPO_ROOT  = path.resolve(__dirname, '..', '..');
+const PHOTOS_JS  = path.join(REPO_ROOT, 'photos.js');
+const STATE_JSON = path.join(__dirname, 'state.json');
+const INBOX_JSON = path.join(__dirname, 'inbox.json');
+const LOG_DIR    = path.join(__dirname, 'log');
+
+// Adapters run in declaration order. seenIds is shared across them so a
+// later adapter doesn't re-emit what an earlier one already added this run.
+const ADAPTERS = [nasaLibrary, flickr];
+const DEFAULT_LIMIT = 50;
+
+// ---------------------------------------------------------------------------
+// State + inbox I/O
+// ---------------------------------------------------------------------------
+
+async function loadJsonOr(filePath, fallback) {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (e) {
+    if (e.code === 'ENOENT') return fallback;
+    throw new Error(`Failed to read ${filePath}: ${e.message}`);
+  }
+}
+
+async function writeJsonAtomic(filePath, data) {
+  const tmp = filePath + '.tmp';
+  await fs.writeFile(tmp, JSON.stringify(data, null, 2));
+  await fs.rename(tmp, filePath);
+}
+
+async function loadState() {
+  const state = await loadJsonOr(STATE_JSON, {
+    seen: [],
+    rejected: [],
+    lastRunAt: null,
+    cursors: {},
+  });
+  // Defensive: ensure arrays exist even if state was hand-edited.
+  state.seen     = state.seen     || [];
+  state.rejected = state.rejected || [];
+  state.cursors  = state.cursors  || {};
+  return state;
+}
+
+async function loadInbox() {
+  const inbox = await loadJsonOr(INBOX_JSON, []);
+  return Array.isArray(inbox) ? inbox : [];
+}
+
+// ---------------------------------------------------------------------------
+// Quality scoring (per EDITORIAL.md must-haves)
+// ---------------------------------------------------------------------------
+
+/**
+ * Score a candidate against EDITORIAL.md's must-haves. Returns:
+ *
+ *   { score: "green" | "yellow" | "red",
+ *     failures: [{ field, reason }, ...] }
+ *
+ * Each failure record contains enough info for the admin Pending tab to
+ * say "this card is yellow because: title is just the source ID,
+ * photographer is generic NASA."
+ */
+function scoreQuality(candidate) {
+  let weak = 0;
+  const failures = [];
+
+  const title = (candidate.title || '').trim();
+  if (!title || title.length < 5) {
+    weak++;
+    failures.push({ field: 'title', reason: 'missing or very short title' });
+  } else if (candidate.source_id && title.includes(candidate.source_id)) {
+    // Many NASA Library titles end with the source ID, e.g. "... -- jsc2024e055108".
+    // Recognizable but not exactly editorial gold.
+    weak += 0.5;
+    failures.push({ field: 'title', reason: 'title contains the source ID — consider rewriting' });
+  }
+
+  if (!candidate.taken_at) {
+    weak++;
+    failures.push({ field: 'taken_at', reason: 'no defensible timestamp' });
+  }
+
+  if (!candidate.photographer || candidate.photographer === 'NASA') {
+    weak++;
+    failures.push({ field: 'photographer', reason: 'photographer is generic "NASA" — specific credit preferred' });
+  }
+
+  const desc = (candidate.description || '').trim();
+  if (!desc) {
+    weak++;
+    failures.push({ field: 'description', reason: 'description is empty' });
+  } else if (desc.length < title.length + 20) {
+    weak += 0.5;
+    failures.push({ field: 'description', reason: 'description barely longer than title — likely lacking context' });
+  }
+
+  let score;
+  if (weak <= 0.5)      score = 'green';
+  else if (weak <= 2)   score = 'yellow';
+  else                  score = 'red';
+
+  return { score, failures };
+}
+
+/**
+ * Best-guess explanation of where the `center` value on a candidate
+ * came from. NASA Library adapters populate this from the API's `center`
+ * code; other sources may derive it differently. Reviewer-friendly text.
+ */
+function explainCenterSource(candidate) {
+  if (!candidate.center) {
+    return {
+      kind: 'absent',
+      note: 'no NASA center associated (likely in-flight, recovery, or non-NASA setting)',
+    };
+  }
+  if (candidate.source === 'nasa_library') {
+    return {
+      kind: 'adapter',
+      field: 'data[0].center',
+      value: candidate.center,
+      note: 'from NASA Image Library API\'s center code',
+    };
+  }
+  return {
+    kind: 'adapter',
+    value: candidate.center,
+    note: `from ${candidate.source} adapter`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main pipeline
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) { printHelp(); return; }
+
+  const startedAt = isoEdt();
+  console.log(`[sync] starting at ${startedAt}`);
+  console.log(`[sync] limit=${args.limit}, fullRescan=${args.fullRescan}, dryRun=${args.dryRun}`);
+
+  // Load state + canonical + inbox
+  const state = await loadState();
+  const photoData = await readPhotosJs(PHOTOS_JS);
+  const inbox = await loadInbox();
+
+  console.log(`[sync] state:    ${state.seen.length} seen, ${state.rejected.length} rejected`);
+  console.log(`[sync] photos.js: ${photoData.photos.length} canonical entries`);
+  console.log(`[sync] inbox.json: ${inbox.length} pending candidates`);
+
+  // Build dedup Set from every place an ID might already be known.
+  const seenIds = new Set([
+    ...photoData.photos.map(p => p.source_id).filter(Boolean),
+    ...inbox.map(c => c.source_id).filter(Boolean),
+    ...state.seen,
+    ...state.rejected,
+  ]);
+  console.log(`[sync] dedup set: ${seenIds.size} known IDs`);
+
+  // Select adapters
+  const adapters = args.source
+      ? ADAPTERS.filter(a => a.NAME === args.source)
+      : ADAPTERS;
+  if (args.source && adapters.length === 0) {
+    throw new Error(`No adapter named "${args.source}" — known: ${ADAPTERS.map(a => a.NAME).join(', ')}`);
+  }
+
+  // Discover from each adapter; share the seenIds set across runs so a
+  // later adapter doesn't re-discover what an earlier one already added.
+  const rawCandidates = [];
+  const perAdapter = {};
+
+  for (const adapter of adapters) {
+    if (rawCandidates.length >= args.limit) break;
+    console.log(`[sync] adapter: ${adapter.NAME}`);
+    const remaining = args.limit - rawCandidates.length;
+    const opts = {
+      seenIds,
+      fullRescan: args.fullRescan,
+      limit: remaining,
+    };
+    if (args.query)   opts.queries = [args.query];
+    if (args.centers) opts.centers = args.centers;
+
+    const result = await adapter.discover(opts);
+    console.log(`[sync]   ${result.candidates.length} candidates discovered`);
+    perAdapter[adapter.NAME] = {
+      added: result.candidates.length,
+      debugInfo: result.debugInfo || null,
+    };
+    rawCandidates.push(...result.candidates);
+  }
+
+  console.log(`[sync] total raw: ${rawCandidates.length}`);
+
+  // Normalize + classify + score
+  const runAddedAt = isoEdt();
+  const processed = rawCandidates.map(raw => {
+    const normalized = normalizeCandidate(raw);
+    const classified = classify(normalized);
+    const { score: quality, failures: qualityFailures } = scoreQuality(normalized);
+    const centerSource = explainCenterSource(normalized);
+
+    // Assemble the unified evidence object. Classifier already populated
+    // evidence.era_matches; we tack on quality and center evidence here so
+    // every reviewer-facing decision is traceable from one place.
+    const evidence = {
+      ...(classified.evidence || {}),
+      quality_failures: qualityFailures,
+      center_source: centerSource,
+    };
+
+    return {
+      ...normalized,
+      classified,
+      evidence,
+      addedAt: runAddedAt,
+      quality,
+    };
+  });
+
+  // Stats by classification
+  const byEra = {};
+  const byConfidence = { high: 0, medium: 0, low: 0 };
+  const byQuality = { green: 0, yellow: 0, red: 0 };
+  for (const c of processed) {
+    byEra[c.classified.era] = (byEra[c.classified.era] || 0) + 1;
+    byConfidence[c.classified.confidence] = (byConfidence[c.classified.confidence] || 0) + 1;
+    byQuality[c.quality] = (byQuality[c.quality] || 0) + 1;
+  }
+  console.log(`[sync] by era:        ${JSON.stringify(byEra)}`);
+  console.log(`[sync] by confidence: ${JSON.stringify(byConfidence)}`);
+  console.log(`[sync] by quality:    ${JSON.stringify(byQuality)}`);
+
+  if (args.dryRun) {
+    console.log('[sync] DRY RUN — not writing inbox/state');
+    for (const c of processed.slice(0, 5)) {
+      console.log('---');
+      console.log(`  ${c.source_id}: ${c.title.slice(0, 70)}`);
+      console.log(`  era:     ${c.classified.era} (${c.classified.confidence}) — ${c.classified.reason}`);
+      console.log(`  quality: ${c.quality}`);
+      console.log(`  by:      ${c.photographer}`);
+      console.log(`  when:    ${c.taken_at}`);
+    }
+    if (processed.length > 5) console.log(`  ...and ${processed.length - 5} more`);
+    return;
+  }
+
+  // Write inbox.json + state.json atomically
+  const updatedInbox = [...inbox, ...processed];
+  for (const c of processed) {
+    if (c.source_id) state.seen.push(c.source_id);
+  }
+  state.lastRunAt = runAddedAt;
+
+  await writeJsonAtomic(INBOX_JSON, updatedInbox);
+  await writeJsonAtomic(STATE_JSON, state);
+
+  // Per-run log: just dump the structured stats. Easy to grep later.
+  // Filename includes millisecond suffix so back-to-back runs in the same
+  // second don't collide.
+  await fs.mkdir(LOG_DIR, { recursive: true });
+  const logName = startedAt
+      .replace(/[:T]/g, '-')
+      .replace(/[+-]\d{2}:\d{2}$/, '');
+  const ms = String(Date.now() % 1000).padStart(3, '0');
+  const logFile = path.join(LOG_DIR, `run-${logName}-${ms}.log`);
+  const logBody = [
+    `[sync] startedAt:    ${startedAt}`,
+    `[sync] finishedAt:   ${isoEdt()}`,
+    `[sync] limit:        ${args.limit}`,
+    `[sync] fullRescan:   ${args.fullRescan}`,
+    `[sync] query:        ${args.query || '(default per adapter)'}`,
+    `[sync] centers:      ${(args.centers || []).join(',') || '(any)'}`,
+    `[sync] dedupSetSize: ${seenIds.size}`,
+    `[sync] discovered:   ${rawCandidates.length}`,
+    `[sync] byEra:        ${JSON.stringify(byEra)}`,
+    `[sync] byConfidence: ${JSON.stringify(byConfidence)}`,
+    `[sync] byQuality:    ${JSON.stringify(byQuality)}`,
+    `[sync] perAdapter:   ${JSON.stringify(perAdapter, null, 2)}`,
+  ].join('\n') + '\n';
+  await fs.writeFile(logFile, logBody);
+
+  console.log(`[sync] wrote ${updatedInbox.length} candidates to inbox`);
+  console.log(`[sync] state: ${state.seen.length} seen total`);
+  console.log(`[sync] log:   ${logFile}`);
+  console.log('[sync] done.');
+}
+
+// ---------------------------------------------------------------------------
+// CLI plumbing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = {
+    limit: DEFAULT_LIMIT,
+    fullRescan: false,
+    source: null,
+    query: null,
+    centers: null,
+    dryRun: false,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--limit')        args.limit = parseInt(argv[++i], 10) || DEFAULT_LIMIT;
+    else if (a === '--full-rescan') args.fullRescan = true;
+    else if (a === '--source')  args.source = argv[++i];
+    else if (a === '--query')   args.query = argv[++i];
+    else if (a === '--centers') args.centers = argv[++i].split(/[,\s]+/).filter(Boolean);
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '-h' || a === '--help') args.help = true;
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node tools/import/sync.js [options]
+
+Options:
+  --limit N          Max new candidates this run, across all sources (default ${DEFAULT_LIMIT})
+  --full-rescan      Ignore the consecutive-seen early-stop heuristic
+  --source NAME      Only run the adapter with this name (e.g. nasa_library)
+  --query "STR"      Override default queries with a single search string
+  --centers LIST     Comma-separated NASA center codes to restrict to (e.g. KSC,JSC)
+  --dry-run          Run discovery + normalize + classify but DO NOT write
+                     to inbox.json, state.json, or log/
+  -h, --help         Show this help
+
+Outputs:
+  tools/import/inbox.json   - candidates pending review (appended)
+  tools/import/state.json   - persistent dedup + cursor state (updated)
+  tools/import/log/*.log    - per-run summary log
+
+Downloads and image resizing are NOT performed yet. The candidate
+image_url field points at the source's original; the admin Pending tab
+can render thumbnails directly. A follow-up will add local download +
+resize to staging/web/.`);
+}
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error('[sync] FAILED:', err.message);
+    console.error(err.stack);
+    process.exit(1);
+  });
+}
+
+module.exports = { main, scoreQuality };


### PR DESCRIPTION
**The big optional one.** Stacks on #40 (schema). Independent of #41 (filters) and #42 (mini-timeline) — none of those are required for the pipeline to function.

Curator-only toolchain under `tools/import/` for discovering new Artemis II imagery from public APIs, normalizing it, classifying it, staging it for review, and merging into `photos.js` via a new "Pending" tab in `admin.html`. **None of this runs on the deployed site.** Runtime entirely unchanged.

📖 **Start with [`tools/import/DESIGN.md`](https://github.com/johnmknight/Artemis-Timeline/blob/pr-4-acquisition-pipeline/tools/import/DESIGN.md)** for architecture rationale; **[`tools/import/EDITORIAL.md`](https://github.com/johnmknight/Artemis-Timeline/blob/pr-4-acquisition-pipeline/tools/import/EDITORIAL.md)** for curation principles.

## Why it might be useful

Right now adding a new photo is several minutes of manual steps:

```
find on NASA Flickr → download → convert -resize 1600x → wrangler r2 put
→ open admin.html → click Add Photo → fill metadata → Export → commit
```

This pipeline compresses that loop to **"click Promote, edit metadata, commit later"** — about 5 seconds per photo through the review UI. Adapters fetch + dedup + normalize + classify; you review batched candidates in the admin tab.

## Why it might NOT belong upstream

- Adds ~3K lines under `tools/import/`, separable but still in the repo
- Introduces a sidecar HTTP server pattern (Node `http.createServer` on `127.0.0.1:8001`) for the admin Pending tab's atomic file mutations
- Adds Node as an implicit prereq for the curator workflow (you already use Node for `fetch-flickr-descriptions.js`, so this isn't truly new)

I won't push on this if it's outside the project's design ethos. Happy to drop, scope down, or split further.

## What's in it

**Source adapters** (`tools/import/sources/`) — implement a tiny common contract:
- `nasa-library.js` — `images-api.nasa.gov` REST API, no key needed
- `flickr.js` — Flickr REST API; reads key from `.env.local` (gitignored)

Both produce normalized `Candidate` records the rest of the pipeline consumes.

**Pipeline** (`tools/import/`):
- `normalize.js` — photographer credit cleanup ("NASA/Joel Kowsky" canonical form), honest-timestamp policy (date-only sources don't pretend to be precise)
- `classify.js` — keyword-based era classifier; captures matched spans for inline `<mark>` highlighting in admin
- `sync.js` — orchestrator: dedup against `photos.js` + `inbox.json` + persisted seen-set + rejected-set, write inbox, write per-run log
- `server.js` — Node-stdlib HTTP server on `127.0.0.1:8001`. Endpoints: `GET /inbox`, `POST /promote`, `POST /reject`, `POST /sync`, `GET /status`. Promote downloads NASA Library's `~large` URL directly to `web/` (no ImageMagick needed for default workflow).

**`admin.html` Pending tab:**

- New tab next to Photos / Audio
- Each candidate card: thumbnail, editable title / time / era / photographer / location / center, confidence + quality badges, inline `<mark>`-highlighted text spans showing which keywords the classifier matched
- Bulk promote / reject / "Run Sync Now"
- Sidecar-offline fallback banner with the start command

**`fetch-flickr-descriptions.js` — minor security fix bundled here:**

The Flickr API key previously committed to this file was revoked by Flickr because this repo is public. Updated to load the key from `tools/import/.env.local` (gitignored) via `shared/env.js`. Anyone running the script needs to drop their own key into `.env.local`; instructions in the file's header comment.

## Stdlib-only, no `npm install`

No `package.json`, no `node_modules/`. Everything uses Node's built-in libraries (`http`, `fs/promises`, native `fetch`, etc.). Matches the project's no-build-step ethos.

## Out of scope

- ❌ No viewer changes (those are #41 and #42)
- ❌ No schema changes (those are #40)
- ❌ No new photo entries

## Tested locally

End-to-end: ran sync against NASA Library + Flickr, reviewed candidates in admin Pending tab, promoted, verified entries landed in `photos.js` with correct schema fields and that the corresponding image downloaded to `web/`. Inbox dedup correctly skips already-known IDs on repeated runs.
