### PR TITLE
Fix FAQ font consistency with main site

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,12 +260,37 @@
     font-size: 10px;
     font-weight: 600;
     transition: all 0.15s;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
   }
   .filter-btn.active { background: #1a237e; border-color: #3949ab; color: #fff; }
   .filter-sep { color: #333; font-size: 10px; margin: 0 4px; }
   .controls-spacer { flex: 1; }
   .info-text { color: #4FC3F7; font-size: 12px; font-weight: 600; }
   .audio-now { color: #888; font-size: 10px; font-style: italic; max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+  /* Audio checkbox indicator */
+  .audio-checkbox {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    border: 1.5px solid currentColor;
+    border-radius: 3px;
+    position: relative;
+    flex-shrink: 0;
+  }
+  #muteBtn.audio-on .audio-checkbox::after {
+    content: '';
+    position: absolute;
+    top: 0px;
+    left: 3px;
+    width: 4px;
+    height: 8px;
+    border-right: 2px solid currentColor;
+    border-bottom: 2px solid currentColor;
+    transform: rotate(45deg);
+  }
 
   /* Centered nav bar above photo */
   .nav-bar {
@@ -912,26 +937,6 @@
       letter-spacing: 0.5px;
       text-transform: uppercase;
       flex-shrink: 0;
-    }
-    .audio-checkbox {
-      display: inline-block;
-      width: 14px;
-      height: 14px;
-      border: 1.5px solid currentColor;
-      border-radius: 3px;
-      position: relative;
-      flex-shrink: 0;
-    }
-    #muteBtn.audio-on .audio-checkbox::after {
-      content: '';
-      position: absolute;
-      top: 0px;
-      left: 3px;
-      width: 4px;
-      height: 8px;
-      border-right: 2px solid currentColor;
-      border-bottom: 2px solid currentColor;
-      transform: rotate(45deg);
     }
 
     .filter-popup-modal {


### PR DESCRIPTION
Fixes #50. 

Added font to Main header and FAQ header for consistency, bringing parody to the two. Also limited the stylized font to only the header and removed from all heading to reduce visual noise.


On Main Page:

Before:
<img width="1109" height="94" alt="Screenshot 2026-05-12 at 6 46 44 PM" src="https://github.com/user-attachments/assets/29d21ccb-b5ae-4d02-bc3b-89822466da48" />

After:
<img width="1133" height="122" alt="Screenshot 2026-05-12 at 6 46 23 PM" src="https://github.com/user-attachments/assets/79d9fffa-3fbf-43a7-8a3b-f1742ece96c0" />

And on faq page:

Before:

<img width="832" height="854" alt="Before" src="https://github.com/user-attachments/assets/22136795-aa51-4ebb-9430-73edfdad6ee5" />

After:

<img width="660" height="751" alt="After" src="https://github.com/user-attachments/assets/15ee3d82-e7cf-4934-ac83-87fc23e0a3e5" />





