### PR TITLE
feat(viewer): add attributed source links with UI button

### DIFF
--- a/index.html
+++ b/index.html
@@ -684,10 +684,10 @@
     .desc-hover { display: none !important; }
   }
   /* Photo description button — top-left corner of the image, opens popup */
-  .photo-desc-btn {
+  .photo-desc-btn,
+  .photo-source-btn {
     position: absolute;
     top: 10px;
-    left: 10px;
     z-index: 4;
     background: rgba(0,0,0,0.55);
     -webkit-backdrop-filter: blur(6px);
@@ -703,8 +703,12 @@
     border-radius: 999px;
     font-family: inherit;
     transition: background 0.15s, border-color 0.15s;
+    text-decoration: none;
   }
-  .photo-desc-btn:hover {
+  .photo-desc-btn { left: 10px; }
+  .photo-source-btn { right: 10px; }
+  .photo-desc-btn:hover,
+  .photo-source-btn:hover {
     background: rgba(0,0,0,0.78);
     border-color: rgba(255,255,255,0.32);
   }
@@ -1266,6 +1270,7 @@
       <img id="currentPhoto" class="photo-img" alt="Current photo">
       <video id="currentVideo" class="photo-img" style="display:none" controls playsinline preload="none"></video>
       <button class="photo-desc-btn" id="photoDescBtn" type="button" onclick="showDescPopup()" style="display:none">Show Desc</button>
+      <a class="photo-source-btn" id="sourceLink" href="#" target="_blank" rel="noopener" style="display:none">Source</a>
     </div>
     <button class="nav-arrow nav-prev" id="prevBtn" title="Previous photo" aria-label="Previous photo">‹</button>
     <button class="nav-arrow nav-next" id="nextBtn" title="Next photo" aria-label="Next photo">›</button>
@@ -1421,6 +1426,33 @@ function getFlickrId(filename) {
   return base || null;
 }
 
+// Resolve the authoritative source page from known filename conventions.
+// Individual entries can override this with source_url when a file needs
+// manual attribution or came from a source that cannot be inferred.
+function getSourceUrl(photo) {
+  if (photo.source_url) return photo.source_url;
+
+  const file = photo.file || '';
+  const stem = file.replace(/\.[^.]+$/, '').replace(/~(large|orig)$/i, '');
+
+  let m = file.match(/^(\d{11})[_-]/);
+  if (m) return `https://www.flickr.com/photo.gne?id=${m[1]}`;
+
+  m = file.match(/^(\d{7})\.jpg$/i);
+  if (m) return `https://www.dvidshub.net/image/${m[1]}`;
+
+  m = stem.match(/^(ART\d+)-([A-Z])-(\d+)$/i);
+  if (m) {
+    return `https://eol.jsc.nasa.gov/SearchPhotos/photo.pl?mission=${m[1].toUpperCase()}&roll=${m[2].toUpperCase()}&frame=${m[3]}`;
+  }
+
+  if (/^(KSC-|NHQ|jsc|art\d+e\d+)/i.test(stem)) {
+    return `https://images.nasa.gov/details/${encodeURIComponent(stem)}`;
+  }
+
+  return null;
+}
+
 
 // --- DATA LOADING ---
 // These are populated by loadPhotoData() from the PHOTO_DATA global (photos.js).
@@ -1434,7 +1466,7 @@ let AUDIO = [];
 function loadPhotoData() {
   const data = PHOTO_DATA;
   data.photos.filter(p => p.enabled !== false).forEach(p => {
-    const entry = {t:edt(p.time),f:p.file,p:p.photographer,loc:p.location,cam:p.camera,set:p.settings,sc:!!p.spacecraft,b:p.batch||0};
+    const entry = {t:edt(p.time),f:p.file,p:p.photographer,loc:p.location,cam:p.camera,set:p.settings,sc:!!p.spacecraft,b:p.batch||0,src:getSourceUrl(p)};
     // Camera ID for filter buttons — use explicit camera_id from data if present,
     // otherwise derive from camera string (z9, gopro, iphone)
     if (p.camera_id) entry.cid = p.camera_id;
@@ -2363,6 +2395,7 @@ function updatePhoto() {
     document.getElementById('metaSettings').textContent = '—';
     document.getElementById('photoTitleRow').style.display = 'none';
     document.getElementById('descSection').style.display = 'none';
+    document.getElementById('sourceLink').style.display = 'none';
     renderTimeline();
     return;
   }
@@ -2424,6 +2457,14 @@ function updatePhoto() {
   document.getElementById('metaCamera').textContent = photo.cam;
   document.getElementById('metaSettings').textContent = photo.set;
   document.getElementById('photoCounter').textContent = `${currentPhotoIdx + 1} / ${filteredPhotos.length}`;
+  const sourceLink = document.getElementById('sourceLink');
+  if (photo.src) {
+    sourceLink.href = photo.src;
+    sourceLink.style.display = '';
+  } else {
+    sourceLink.removeAttribute('href');
+    sourceLink.style.display = 'none';
+  }
   if (photo.desc) {
     document.getElementById('descSection').style.display = '';
     document.getElementById('metaDesc').textContent = photo.desc;

--- a/index.html
+++ b/index.html
@@ -1469,7 +1469,7 @@ function getSourceUrl(photo) {
   if (photo.source_url) return photo.source_url;
 
   const stem = (photo.file || '').replace(/\.[^.]+$/, '').replace(/~(large|orig)$/i, '');
-  
+
   let m = stem.match(/^(\d{11})(?:[_-]|$)/);
   if (m) return `https://www.flickr.com/photo.gne?id=${m[1]}`;
 

--- a/index.html
+++ b/index.html
@@ -712,6 +712,42 @@
     background: rgba(0,0,0,0.78);
     border-color: rgba(255,255,255,0.32);
   }
+  .photo-source-btn.disabled {
+    color: rgba(255,255,255,0.52);
+    cursor: not-allowed;
+    background: rgba(80,80,90,0.42);
+    border-color: rgba(255,255,255,0.12);
+  }
+  .photo-source-btn.disabled:hover,
+  .photo-source-btn.disabled:focus {
+    background: rgba(80,80,90,0.5);
+    border-color: rgba(255,255,255,0.18);
+  }
+  .photo-source-btn.disabled::after {
+    content: attr(data-tooltip);
+    display: none;
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    width: min(260px, calc(100vw - 32px));
+    padding: 8px 10px;
+    border: 1px solid rgba(255,255,255,0.16);
+    border-radius: 6px;
+    background: rgba(10,10,20,0.94);
+    color: #ddd;
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0;
+    line-height: 1.35;
+    text-transform: none;
+    white-space: normal;
+    text-align: left;
+    box-shadow: 0 6px 18px rgba(0,0,0,0.45);
+  }
+  .photo-source-btn.disabled:hover::after,
+  .photo-source-btn.disabled:focus::after {
+    display: block;
+  }
 
   /* Long-description popup */
   .desc-popup-modal {
@@ -2460,10 +2496,20 @@ function updatePhoto() {
   const sourceLink = document.getElementById('sourceLink');
   if (photo.src) {
     sourceLink.href = photo.src;
+    sourceLink.classList.remove('disabled');
+    sourceLink.removeAttribute('aria-disabled');
+    sourceLink.removeAttribute('data-tooltip');
+    sourceLink.removeAttribute('tabindex');
+    sourceLink.title = 'Open source photo';
     sourceLink.style.display = '';
   } else {
     sourceLink.removeAttribute('href');
-    sourceLink.style.display = 'none';
+    sourceLink.classList.add('disabled');
+    sourceLink.setAttribute('aria-disabled', 'true');
+    sourceLink.setAttribute('data-tooltip', 'Source URL missing. Have the original? Please open an issue on GitHub.');
+    sourceLink.setAttribute('tabindex', '0');
+    sourceLink.title = 'Source URL missing. Have the original? Please open an issue on GitHub.';
+    sourceLink.style.display = '';
   }
   if (photo.desc) {
     document.getElementById('descSection').style.display = '';

--- a/index.html
+++ b/index.html
@@ -1468,13 +1468,12 @@ function getFlickrId(filename) {
 function getSourceUrl(photo) {
   if (photo.source_url) return photo.source_url;
 
-  const file = photo.file || '';
-  const stem = file.replace(/\.[^.]+$/, '').replace(/~(large|orig)$/i, '');
-
-  let m = file.match(/^(\d{11})[_-]/);
+  const stem = (photo.file || '').replace(/\.[^.]+$/, '').replace(/~(large|orig)$/i, '');
+  
+  let m = stem.match(/^(\d{11})(?:[_-]|$)/);
   if (m) return `https://www.flickr.com/photo.gne?id=${m[1]}`;
 
-  m = file.match(/^(\d{7})\.jpg$/i);
+  m = stem.match(/^(\d{7})$/);
   if (m) return `https://www.dvidshub.net/image/${m[1]}`;
 
   m = stem.match(/^(ART\d+)-([A-Z])-(\d+)$/i);

--- a/index.html
+++ b/index.html
@@ -1306,7 +1306,7 @@
       <img id="currentPhoto" class="photo-img" alt="Current photo">
       <video id="currentVideo" class="photo-img" style="display:none" controls playsinline preload="none"></video>
       <button class="photo-desc-btn" id="photoDescBtn" type="button" onclick="showDescPopup()" style="display:none">Show Desc</button>
-      <a class="photo-source-btn" id="sourceLink" href="#" target="_blank" rel="noopener" style="display:none">Source</a>
+      <a class="photo-source-btn" id="sourceLink" href="#" target="_blank" rel="noopener" style="display:none">View Source</a>
     </div>
     <button class="nav-arrow nav-prev" id="prevBtn" title="Previous photo" aria-label="Previous photo">‹</button>
     <button class="nav-arrow nav-next" id="nextBtn" title="Next photo" aria-label="Next photo">›</button>
@@ -2499,15 +2499,18 @@ function updatePhoto() {
     sourceLink.removeAttribute('aria-disabled');
     sourceLink.removeAttribute('data-tooltip');
     sourceLink.removeAttribute('tabindex');
-    sourceLink.title = 'Open source photo';
+    sourceLink.title = 'Open source page';
     sourceLink.style.display = '';
   } else {
     sourceLink.removeAttribute('href');
     sourceLink.classList.add('disabled');
     sourceLink.setAttribute('aria-disabled', 'true');
-    sourceLink.setAttribute('data-tooltip', 'Source URL missing. Have the original? Please open an issue on GitHub.');
+
+    const missingSourceMessage = 'Source page URL missing. Have the original? Please open an issue on GitHub.';
+    sourceLink.setAttribute('data-tooltip', missingSourceMessage);
     sourceLink.setAttribute('tabindex', '0');
-    sourceLink.title = 'Source URL missing. Have the original? Please open an issue on GitHub.';
+    sourceLink.title = missingSourceMessage;
+
     sourceLink.style.display = '';
   }
   if (photo.desc) {


### PR DESCRIPTION
**Attribution note:** This PR now incorporates source-link work originally proposed in #35 by @skittlz444, with their permission to fold useful parts into #52.

## Summary

- Add a `View Source` button to the photo viewer so users can open the original source page for timeline media.
> <img width="184" height="75" alt="image" src="https://github.com/user-attachments/assets/610095c1-bed1-4a0c-b33b-b4a1fdf8820f" />
- Resolve source page URLs from known filename conventions for Flickr, DVIDS, NASA Earth Observations Lab, and NASA Images.
- Support an explicit `source_url` override for entries that cannot be inferred automatically.
- Show a disabled source state with a tooltip when no source page URL is available.
> <img width="298" height="100" alt="image" src="https://github.com/user-attachments/assets/7efb25d1-7169-44dc-a546-783e69152745" />
- Keep source-page navigation separate from the timeline metadata panel.

## Attribution

This PR combines overlapping source-link work from:

- #35 by @skittlz444, which first proposed and implemented filename-derived source links in the metadata panel.
- #52 by @jaurund, which added the overlay `View Source` button, disabled missing-source state, and `source_url` override support.

After reviewing both approaches, this keeps the overlay source-button UX from #52, incorporates the normalized filename matching approach from #35, and leaves source navigation separate from the curated metadata panel.

> **Reason:** _The metadata panel stays focused on curated timeline metadata, while source-page navigation is handled separately in the viewer UI._

Context:
- @skittlz444 explicitly suggested updating #52 with useful parts from #35.
- @jaurund followed up by reviewing both approaches, testing the combined implementation, and adding this attribution.

## Testing

- Ran the site locally with `python -m http.server 8000`.
- Verified that `View Source` opens inferred source pages for supported filename patterns:
  - Flickr
  - DVIDS
  - NASA Earth Observations Lab
  - NASA Images
- Verified that entries without a source page URL show the disabled state and tooltip instead of a broken link.
- Verified that the button is hidden when no photo is selected.
- Verified that unresolved media remains unresolved unless a verified `source_url` is added manually.
### Mobile testing
- Verified on mobile that the `VIEW SOURCE` button renders correctly, and is identical in style to the `SHOW DESC` button
- Verified on mobile that the disabled `View Source` button shows the missing-source tooltip instead of navigating


## Notes

- No framework, build step, or dependency changes.
- This PR only updates the existing static `index.html` viewer code.
- Manual `source_url` additions for currently unresolved Instagram/YouTube/Astronomy Live/local media can be handled separately once exact source page URLs are verified.
