### PR TITLE
Fix #54: Remove forced display of audio dots on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -816,7 +816,6 @@
     .timeline-playhead { top: 0; height: 34px; }
     /* Keep activity bars, audio dots, and day labels visible on mobile */
     .timeline-labels { font-size: 8px; margin-top: 4px; }
-    .timeline-audio-dots { display: block; }
     .audio-dot { width: 6px; height: 6px; top: 2px; transform: translateX(-3px); }
     .photo-dot { width: 6px; height: 6px; top: 2px; transform: translateX(-3px); }
     .photo-dot.active { width: 8px; height: 8px; top: 1px; transform: translateX(-4px); }


### PR DESCRIPTION
Fixed yellow audio bubbles showing on mobile when audio is initially disabled. Removed `.timeline-audio-dots { display: block; }` from mobile CSS, so now JavaScript controls visibility based on audio state like it does on desktop.

Fixes #54